### PR TITLE
Fix build for current rust master

### DIFF
--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -28,7 +28,7 @@ use num::{zero, one, BaseNum, BaseFloat};
 use std::fmt;
 use std::num::Float;
 
-pub trait Aabb<S: BaseNum, V: Vector<S>, P: Point<S, V>> {
+pub trait Aabb<S: BaseNum, V: Vector<S>, P: Point<S, V>>: Sized {
     /// Create a new AABB using two points as opposing corners.
     fn new(p1: P, p2: P) -> Self;
 
@@ -84,7 +84,7 @@ pub trait Aabb<S: BaseNum, V: Vector<S>, P: Point<S, V>> {
 }
 
 /// A two-dimensional AABB, aka a rectangle.
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Aabb2<S> {
     pub min: Point2<S>,
     pub max: Point2<S>,
@@ -129,7 +129,7 @@ impl<S: BaseNum> fmt::Show for Aabb2<S> {
 }
 
 /// A three-dimensional AABB, aka a rectangular prism.
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Aabb3<S> {
     pub min: Point3<S>,
     pub max: Point3<S>,

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -17,16 +17,17 @@
 
 use std::fmt;
 use std::f64;
+use std::ops::{Add, Sub, Mul, Neg};
 use std::num::{cast, Float};
 
 use approx::ApproxEq;
 use num::{BaseFloat, One, one, Zero, zero};
 
 /// An angle, in radians
-#[deriving(Copy, Clone, PartialEq, PartialOrd, Hash, RustcEncodable, RustcDecodable, Rand)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Hash, RustcEncodable, RustcDecodable, Rand)]
 pub struct Rad<S> { pub s: S }
 /// An angle, in degrees
-#[deriving(Copy, Clone, PartialEq, PartialOrd, Hash, RustcEncodable, RustcDecodable, Rand)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Hash, RustcEncodable, RustcDecodable, Rand)]
 pub struct Deg<S> { pub s: S }
 
 /// Create a new angle, in radians

--- a/src/approx.rs
+++ b/src/approx.rs
@@ -16,7 +16,7 @@
 use std::num;
 use std::num::Float;
 
-pub trait ApproxEq<T: Float> {
+pub trait ApproxEq<T: Float>: Sized {
     fn approx_epsilon(_hack: Option<Self>) -> T {
         num::cast(1.0e-5f64).unwrap()
     }

--- a/src/array.rs
+++ b/src/array.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use std::mem;
+use std::ops::{Index, IndexMut};
 use std::ptr;
 
 /// An array containing elements of type `Element`

--- a/src/cgmath.rs
+++ b/src/cgmath.rs
@@ -33,6 +33,10 @@
 //! `look_at`, `from_angle`, `from_euler`, and `from_axis_angle` methods.
 //! These are provided for convenience.
 
+// This is necessary for #[derive(RustcEncodable, RustcDecodable)] for now.
+// See https://github.com/nikomatsakis/rust/commit/c61a0092bc236c4be6
+#![feature(old_orphan_check)]
+
 extern crate "rustc-serialize" as rustc_serialize;
 
 // Re-exports

--- a/src/cylinder.rs
+++ b/src/cylinder.rs
@@ -18,7 +18,7 @@
 use point::Point3;
 use vector::Vector3;
 
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Cylinder<S> {
     pub center: Point3<S>,
     pub axis: Vector3<S>,

--- a/src/frustum.rs
+++ b/src/frustum.rs
@@ -22,7 +22,7 @@ use plane::Plane;
 use point::Point3;
 use vector::{Vector, EuclideanVector};
 
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Frustum<S> {
     pub left:   Plane<S>,
     pub right:  Plane<S>,
@@ -59,7 +59,7 @@ Frustum<S> {
     }
 }
 
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct FrustumPoints<S> {
     pub near_top_left:     Point3<S>,
     pub near_top_right:    Point3<S>,

--- a/src/line.rs
+++ b/src/line.rs
@@ -22,7 +22,7 @@ use ray::{Ray2};
 use intersect::Intersect;
 
 /// A generic directed line segment from `origin` to `dest`.
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Line<P> {
     pub origin: P,
     pub dest: P,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -17,6 +17,7 @@
 
 use std::fmt;
 use std::mem;
+use std::ops::{Add, Sub, Mul, Neg, Index, IndexMut};
 use std::num::cast;
 
 use angle::{Rad, sin, cos, sin_cos};
@@ -29,15 +30,15 @@ use vector::{Vector, EuclideanVector};
 use vector::{Vector2, Vector3, Vector4};
 
 /// A 2 x 2, column major matrix
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable, Rand)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable, Rand)]
 pub struct Matrix2<S> { pub x: Vector2<S>, pub y: Vector2<S> }
 
 /// A 3 x 3, column major matrix
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable, Rand)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable, Rand)]
 pub struct Matrix3<S> { pub x: Vector3<S>, pub y: Vector3<S>, pub z: Vector3<S> }
 
 /// A 4 x 4, column major matrix
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable, Rand)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable, Rand)]
 pub struct Matrix4<S> { pub x: Vector4<S>, pub y: Vector4<S>, pub z: Vector4<S>, pub w: Vector4<S> }
 
 
@@ -287,7 +288,8 @@ Matrix4<S> {
 pub trait Matrix<S: BaseFloat, V: Clone + Vector<S>>: Array2<V, V, S>
                                                     + Neg<Self>
                                                     + Zero + One
-                                                    + ApproxEq<S> {
+                                                    + ApproxEq<S>
+                                                    + Sized {
     /// Multiply this matrix by a scalar, returning the new matrix.
     fn mul_s(&self, s: S) -> Self;
     /// Divide this matrix by a scalar, returning the new matrix.
@@ -393,9 +395,9 @@ impl<S: BaseFloat> One for Matrix2<S> { #[inline] fn one() -> Matrix2<S> { Matri
 impl<S: BaseFloat> One for Matrix3<S> { #[inline] fn one() -> Matrix3<S> { Matrix3::identity() } }
 impl<S: BaseFloat> One for Matrix4<S> { #[inline] fn one() -> Matrix4<S> { Matrix4::identity() } }
 
-impl<S> FixedArray<[[S, ..2], ..2]> for Matrix2<S> {
+impl<S> FixedArray<[[S; 2]; 2]> for Matrix2<S> {
     #[inline]
-    fn into_fixed(self) -> [[S, ..2], ..2] {
+    fn into_fixed(self) -> [[S; 2]; 2] {
         match self {
             Matrix2 { x, y } => [
                 x.into_fixed(),
@@ -405,17 +407,17 @@ impl<S> FixedArray<[[S, ..2], ..2]> for Matrix2<S> {
     }
 
     #[inline]
-    fn as_fixed<'a>(&'a self) -> &'a [[S, ..2], ..2] {
+    fn as_fixed<'a>(&'a self) -> &'a [[S; 2]; 2] {
         unsafe { mem::transmute(self) }
     }
 
     #[inline]
-    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [[S, ..2], ..2] {
+    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [[S; 2]; 2] {
         unsafe { mem::transmute(self) }
     }
 
     #[inline]
-    fn from_fixed(_v: [[S, ..2], ..2]) -> Matrix2<S> {
+    fn from_fixed(_v: [[S; 2]; 2]) -> Matrix2<S> {
         // match v {
         //     [x, y] => Matrix2 {
         //         x: FixedArray::from_fixed(x),
@@ -426,12 +428,12 @@ impl<S> FixedArray<[[S, ..2], ..2]> for Matrix2<S> {
     }
 
     #[inline]
-    fn from_fixed_ref<'a>(v: &'a [[S, ..2], ..2]) -> &'a Matrix2<S> {
+    fn from_fixed_ref<'a>(v: &'a [[S; 2]; 2]) -> &'a Matrix2<S> {
         unsafe { mem::transmute(v) }
     }
 
     #[inline]
-    fn from_fixed_mut<'a>(v: &'a mut [[S, ..2], ..2]) -> &'a mut Matrix2<S> {
+    fn from_fixed_mut<'a>(v: &'a mut [[S; 2]; 2]) -> &'a mut Matrix2<S> {
         unsafe { mem::transmute(v) }
     }
 }
@@ -471,9 +473,9 @@ impl<S: Copy + 'static> Array2<Vector2<S>, Vector2<S>, S> for Matrix2<S> {
     }
 }
 
-impl<S> FixedArray<[[S, ..3], ..3]> for Matrix3<S> {
+impl<S> FixedArray<[[S; 3]; 3]> for Matrix3<S> {
     #[inline]
-    fn into_fixed(self) -> [[S, ..3], ..3] {
+    fn into_fixed(self) -> [[S; 3]; 3] {
         match self {
             Matrix3 { x, y, z } => [
                 x.into_fixed(),
@@ -484,17 +486,17 @@ impl<S> FixedArray<[[S, ..3], ..3]> for Matrix3<S> {
     }
 
     #[inline]
-    fn as_fixed<'a>(&'a self) -> &'a [[S, ..3], ..3] {
+    fn as_fixed<'a>(&'a self) -> &'a [[S; 3]; 3] {
         unsafe { mem::transmute(self) }
     }
 
     #[inline]
-    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [[S, ..3], ..3] {
+    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [[S; 3]; 3] {
         unsafe { mem::transmute(self) }
     }
 
     #[inline]
-    fn from_fixed(_v: [[S, ..3], ..3]) -> Matrix3<S> {
+    fn from_fixed(_v: [[S; 3]; 3]) -> Matrix3<S> {
         // match v {
         //     [x, y, z] => Matrix3 {
         //         x: FixedArray::from_fixed(x),
@@ -506,12 +508,12 @@ impl<S> FixedArray<[[S, ..3], ..3]> for Matrix3<S> {
     }
 
     #[inline]
-    fn from_fixed_ref<'a>(v: &'a [[S, ..3], ..3]) -> &'a Matrix3<S> {
+    fn from_fixed_ref<'a>(v: &'a [[S; 3]; 3]) -> &'a Matrix3<S> {
         unsafe { mem::transmute(v) }
     }
 
     #[inline]
-    fn from_fixed_mut<'a>(v: &'a mut [[S, ..3], ..3]) -> &'a mut Matrix3<S> {
+    fn from_fixed_mut<'a>(v: &'a mut [[S; 3]; 3]) -> &'a mut Matrix3<S> {
         unsafe { mem::transmute(v) }
     }
 }
@@ -554,9 +556,9 @@ impl<S: Copy + 'static> Array2<Vector3<S>, Vector3<S>, S> for Matrix3<S> {
     }
 }
 
-impl<S> FixedArray<[[S, ..4], ..4]> for Matrix4<S> {
+impl<S> FixedArray<[[S; 4]; 4]> for Matrix4<S> {
     #[inline]
-    fn into_fixed(self) -> [[S, ..4], ..4] {
+    fn into_fixed(self) -> [[S; 4]; 4] {
         match self {
             Matrix4 { x, y, z, w } => [
                 x.into_fixed(),
@@ -568,17 +570,17 @@ impl<S> FixedArray<[[S, ..4], ..4]> for Matrix4<S> {
     }
 
     #[inline]
-    fn as_fixed<'a>(&'a self) -> &'a [[S, ..4], ..4] {
+    fn as_fixed<'a>(&'a self) -> &'a [[S; 4]; 4] {
         unsafe { mem::transmute(self) }
     }
 
     #[inline]
-    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [[S, ..4], ..4] {
+    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [[S; 4]; 4] {
         unsafe { mem::transmute(self) }
     }
 
     #[inline]
-    fn from_fixed(_v: [[S, ..4], ..4]) -> Matrix4<S> {
+    fn from_fixed(_v: [[S; 4]; 4]) -> Matrix4<S> {
         // match v {
         //     [x, y, z, w] => Matrix4 {
         //         x: FixedArray::from_fixed(x),
@@ -591,12 +593,12 @@ impl<S> FixedArray<[[S, ..4], ..4]> for Matrix4<S> {
     }
 
     #[inline]
-    fn from_fixed_ref<'a>(v: &'a [[S, ..4], ..4]) -> &'a Matrix4<S> {
+    fn from_fixed_ref<'a>(v: &'a [[S; 4]; 4]) -> &'a Matrix4<S> {
         unsafe { mem::transmute(v) }
     }
 
     #[inline]
-    fn from_fixed_mut<'a>(v: &'a mut [[S, ..4], ..4]) -> &'a mut Matrix4<S> {
+    fn from_fixed_mut<'a>(v: &'a mut [[S; 4]; 4]) -> &'a mut Matrix4<S> {
         unsafe { mem::transmute(v) }
     }
 }

--- a/src/num.rs
+++ b/src/num.rs
@@ -17,6 +17,7 @@ use approx::ApproxEq;
 
 use std::cmp;
 use std::fmt;
+use std::ops::{Add, Sub, Mul, Div, Neg, Rem};
 use std::num::{FloatMath, Int, NumCast, Float};
 
 /// A trait providing a [partial ordering](http://mathworld.wolfram.com/PartialOrder.html).

--- a/src/obb.rs
+++ b/src/obb.rs
@@ -18,14 +18,14 @@
 use point::{Point2, Point3};
 use vector::{Vector2, Vector3};
 
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Obb2<S> {
     pub center: Point2<S>,
     pub axis: Vector2<S>,
     pub extents: Vector2<S>,
 }
 
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Obb3<S> {
     pub center: Point3<S>,
     pub axis: Vector3<S>,

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -39,7 +39,7 @@ use vector::{Vector, EuclideanVector};
 /// The `A*x + B*y + C*z - D = 0` form is preferred over the other common
 /// alternative, `A*x + B*y + C*z + D = 0`, because it tends to avoid
 /// superfluous negations (see _Real Time Collision Detection_, p. 55).
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Plane<S> {
     pub n: Vector3<S>,
     pub d: S,

--- a/src/point.rs
+++ b/src/point.rs
@@ -19,6 +19,7 @@
 
 use std::fmt;
 use std::mem;
+use std::ops::{Index, IndexMut};
 
 use approx::ApproxEq;
 use array::{Array1, FixedArray};
@@ -26,11 +27,11 @@ use num::{BaseNum, BaseFloat, one, zero};
 use vector::*;
 
 /// A point in 2-dimensional space.
-#[deriving(PartialEq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
 pub struct Point2<S> { pub x: S, pub y: S }
 
 /// A point in 3-dimensional space.
-#[deriving(PartialEq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
 pub struct Point3<S> { pub x: S, pub y: S, pub z: S }
 
 
@@ -101,35 +102,35 @@ pub trait Point<S: BaseNum, V: Vector<S>>: Array1<S> + Clone {
     fn max(&self, p: &Self) -> Self;
 }
 
-impl<S> FixedArray<[S, ..2]> for Point2<S> {
+impl<S> FixedArray<[S; 2]> for Point2<S> {
     #[inline]
-    fn into_fixed(self) -> [S, ..2] {
+    fn into_fixed(self) -> [S; 2] {
         match self { Point2 { x, y } => [x, y] }
     }
 
     #[inline]
-    fn as_fixed<'a>(&'a self) -> &'a [S, ..2] {
+    fn as_fixed<'a>(&'a self) -> &'a [S; 2] {
         unsafe { mem::transmute(self) }
     }
 
     #[inline]
-    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [S, ..2] {
+    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [S; 2] {
         unsafe { mem::transmute(self) }
     }
 
     #[inline]
-    fn from_fixed(_v: [S, ..2]) -> Point2<S> {
+    fn from_fixed(_v: [S; 2]) -> Point2<S> {
         // match v { [x, y] => Point2 { x: x, y: y } }
         panic!("Unimplemented, pending a fix for rust-lang/rust#16418");
     }
 
     #[inline]
-    fn from_fixed_ref<'a>(v: &'a [S, ..2]) -> &'a Point2<S> {
+    fn from_fixed_ref<'a>(v: &'a [S; 2]) -> &'a Point2<S> {
         unsafe { mem::transmute(v) }
     }
 
     #[inline]
-    fn from_fixed_mut<'a>(v: &'a mut [S, ..2]) -> &'a mut Point2<S> {
+    fn from_fixed_mut<'a>(v: &'a mut [S; 2]) -> &'a mut Point2<S> {
         unsafe { mem::transmute(v) }
     }
 }
@@ -255,35 +256,35 @@ impl<S: BaseFloat> ApproxEq<S> for Point2<S> {
     }
 }
 
-impl<S> FixedArray<[S, ..3]> for Point3<S> {
+impl<S> FixedArray<[S; 3]> for Point3<S> {
     #[inline]
-    fn into_fixed(self) -> [S, ..3] {
+    fn into_fixed(self) -> [S; 3] {
         match self { Point3 { x, y, z } => [x, y, z] }
     }
 
     #[inline]
-    fn as_fixed<'a>(&'a self) -> &'a [S, ..3] {
+    fn as_fixed<'a>(&'a self) -> &'a [S; 3] {
         unsafe { mem::transmute(self) }
     }
 
     #[inline]
-    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [S, ..3] {
+    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [S; 3] {
         unsafe { mem::transmute(self) }
     }
 
     #[inline]
-    fn from_fixed(_v: [S, ..3]) -> Point3<S> {
+    fn from_fixed(_v: [S; 3]) -> Point3<S> {
         // match v { [x, y, z] => Point3 { x: x, y: y, z: z } }
         panic!("Unimplemented, pending a fix for rust-lang/rust#16418")
     }
 
     #[inline]
-    fn from_fixed_ref<'a>(v: &'a [S, ..3]) -> &'a Point3<S> {
+    fn from_fixed_ref<'a>(v: &'a [S; 3]) -> &'a Point3<S> {
         unsafe { mem::transmute(v) }
     }
 
     #[inline]
-    fn from_fixed_mut<'a>(v: &'a mut [S, ..3]) -> &'a mut Point3<S> {
+    fn from_fixed_mut<'a>(v: &'a mut [S; 3]) -> &'a mut Point3<S> {
         unsafe { mem::transmute(v) }
     }
 }

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -69,7 +69,7 @@ pub trait Projection<S>: ToMatrix4<S> {
 }
 
 /// A perspective projection based on a vertical field-of-view angle.
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct PerspectiveFov<S, A> {
     pub fovy:   A,
     pub aspect: S,
@@ -143,7 +143,7 @@ impl<S: BaseFloat, A: Angle<S>> ToMatrix4<S> for PerspectiveFov<S, A> {
 }
 
 /// A perspective projection with arbitrary left/right/bottom/top distances
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Perspective<S> {
     pub left:   S,  right:  S,
     pub bottom: S,  top:    S,
@@ -193,7 +193,7 @@ impl<S: BaseFloat + 'static> ToMatrix4<S> for Perspective<S> {
 }
 
 /// An orthographic projection with arbitrary left/right/bottom/top distances
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Ortho<S> {
     pub left:   S,  right:  S,
     pub bottom: S,  top:    S,

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -14,8 +14,9 @@
 // limitations under the License.
 
 use std::fmt;
-use std::mem;
 use std::f64;
+use std::mem;
+use std::ops::{Neg, Index, IndexMut};
 use std::num::{cast, Float};
 
 use angle::{Angle, Rad, acos, sin, sin_cos, rad};
@@ -29,7 +30,7 @@ use vector::{Vector3, Vector, EuclideanVector};
 
 /// A [quaternion](https://en.wikipedia.org/wiki/Quaternion) in scalar/vector
 /// form.
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable, Rand)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable, Rand)]
 pub struct Quaternion<S> { pub s: S, pub v: Vector3<S> }
 
 /// Represents types which can be expressed as a quaternion.
@@ -52,7 +53,7 @@ impl<S: Copy + BaseFloat> Array1<S> for Quaternion<S> {
 impl<S: BaseFloat> Index<uint, S> for Quaternion<S> {
     #[inline]
     fn index<'a>(&'a self, i: &uint) -> &'a S {
-        let slice: &[S, ..4] = unsafe { mem::transmute(self) };
+        let slice: &[S; 4] = unsafe { mem::transmute(self) };
         &slice[*i]
     }
 }
@@ -60,7 +61,7 @@ impl<S: BaseFloat> Index<uint, S> for Quaternion<S> {
 impl<S: BaseFloat> IndexMut<uint, S> for Quaternion<S> {
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &uint) -> &'a mut S {
-        let slice: &'a mut [S, ..4] = unsafe { mem::transmute(self) };
+        let slice: &'a mut [S; 4] = unsafe { mem::transmute(self) };
         &mut slice[*i]
     }
 }

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -19,7 +19,7 @@ use vector::{Vector, Vector2, Vector3};
 
 /// A generic ray starting at `origin` and extending infinitely in
 /// `direction`.
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Ray<P,V> {
     pub origin: P,
     pub direction: V,

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -26,7 +26,7 @@ use vector::{Vector, Vector2, Vector3};
 
 /// A trait for a generic rotation. A rotation is a transformation that
 /// creates a circular motion, and preserves at least one point in the space.
-pub trait Rotation<S: BaseNum, V: Vector<S>, P: Point<S, V>>: PartialEq + ApproxEq<S> {
+pub trait Rotation<S: BaseNum, V: Vector<S>, P: Point<S, V>>: PartialEq + ApproxEq<S> + Sized {
     /// Create the identity transform (causes no transformation).
     fn identity() -> Self;
 
@@ -161,7 +161,7 @@ pub trait Rotation3<S: BaseNum>: Rotation<S, Vector3<S>, Point3<S>>
 /// let unit_y3 = rot_half.concat(&rot_half).rotate_vector(&unit_x);
 /// assert!(unit_y3.approx_eq(&unit_y2));
 /// ```
-#[deriving(PartialEq, Copy, Clone, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Copy, Clone, RustcEncodable, RustcDecodable)]
 pub struct Basis2<S> {
     mat: Matrix2<S>
 }
@@ -239,7 +239,7 @@ impl<S: BaseFloat + 'static> Rotation2<S> for Basis2<S> {
 /// inversion, can be implemented more efficiently than the implementations for
 /// `math::Matrix3`. To ensure orthogonality is maintained, the operations have
 /// been restricted to a subeset of those implemented on `Matrix3`.
-#[deriving(PartialEq, Copy, Clone, RustcEncodable, RustcDecodable)]
+#[derive(PartialEq, Copy, Clone, RustcEncodable, RustcDecodable)]
 pub struct Basis3<S> {
     mat: Matrix3<S>
 }

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -21,7 +21,7 @@ use point::{Point, Point3};
 use ray::Ray3;
 use vector::Vector;
 
-#[deriving(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Sphere<S> {
     pub center: Point3<S>,
     pub radius: S,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -26,7 +26,7 @@ use vector::{Vector, Vector3};
 /// A trait representing an [affine
 /// transformation](https://en.wikipedia.org/wiki/Affine_transformation) that
 /// can be applied to points or vectors. An affine transformation is one which
-pub trait Transform<S: BaseNum, V: Vector<S>, P: Point<S,V>> {
+pub trait Transform<S: BaseNum, V: Vector<S>, P: Point<S,V>>: Sized {
     /// Create an identity transformation. That is, a transformation which
     /// does nothing.
     fn identity() -> Self;
@@ -76,7 +76,7 @@ pub trait Transform<S: BaseNum, V: Vector<S>, P: Point<S,V>> {
 
 /// A generic transformation consisting of a rotation,
 /// displacement vector and scale amount.
-#[deriving(Copy, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, RustcEncodable, RustcDecodable)]
 pub struct Decomposed<S, V, R> {
     pub scale: S,
     pub rot: R,
@@ -159,7 +159,7 @@ impl<S: BaseFloat, R: fmt::Show + Rotation3<S>> fmt::Show for Decomposed<S,Vecto
 }
 
 /// A homogeneous transformation matrix.
-#[deriving(Copy, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, RustcEncodable, RustcDecodable)]
 pub struct AffineMatrix3<S> {
     pub mat: Matrix4<S>,
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -98,6 +98,7 @@
 
 use std::fmt;
 use std::mem;
+use std::ops::{Add, Sub, Mul, Div, Neg, Rem, Index, IndexMut};
 use std::num::NumCast;
 
 use angle::{Rad, atan2, acos};
@@ -108,7 +109,7 @@ use num::{BaseNum, BaseFloat, Zero, One, zero, one};
 /// A trait that specifies a range of numeric operations for vectors. Not all
 /// of these make sense from a linear algebra point of view, but are included
 /// for pragmatic reasons.
-pub trait Vector<S: BaseNum>: Array1<S> + Zero + One + Neg<Self> {
+pub trait Vector<S: BaseNum>: Array1<S> + Zero + One + Neg<Self> + Sized {
     /// Add a scalar to this vector, returning a new vector.
     fn add_s(&self, s: S) -> Self;
     /// Subtract a scalar from this vector, returning a new vector.
@@ -177,7 +178,7 @@ pub trait Vector<S: BaseNum>: Array1<S> + Zero + One + Neg<Self> {
 // Utility macro for generating associated functions for the vectors
 macro_rules! vec(
     ($Self:ident <$S:ident> { $($field:ident),+ }, $n:expr) => (
-        #[deriving(PartialEq, Eq, Copy, Clone, Hash, RustcEncodable, RustcDecodable, Rand)]
+        #[derive(PartialEq, Eq, Copy, Clone, Hash, RustcEncodable, RustcDecodable, Rand)]
         pub struct $Self<S> { $(pub $field: S),+ }
 
         impl<$S> $Self<$S> {
@@ -217,35 +218,35 @@ macro_rules! vec(
             }
         }
 
-        impl<$S> FixedArray<[$S, ..$n]> for $Self<$S> {
+        impl<$S> FixedArray<[$S; $n]> for $Self<$S> {
             #[inline]
-            fn into_fixed(self) -> [$S, ..$n] {
+            fn into_fixed(self) -> [$S; $n] {
                 match self { $Self { $($field),+ } => [$($field),+] }
             }
 
             #[inline]
-            fn as_fixed<'a>(&'a self) -> &'a [$S, ..$n] {
+            fn as_fixed<'a>(&'a self) -> &'a [$S; $n] {
                 unsafe { mem::transmute(self) }
             }
 
             #[inline]
-            fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [$S, ..$n] {
+            fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [$S; $n] {
                 unsafe { mem::transmute(self) }
             }
 
             #[inline]
-            fn from_fixed(_v: [$S, ..$n]) -> $Self<$S> {
+            fn from_fixed(_v: [$S; $n]) -> $Self<$S> {
                 // match v { [$($field),+] => $Self { $($field: $field),+ } }
                 panic!("Unimplemented, pending a fix for rust-lang/rust#16418");
             }
 
             #[inline]
-            fn from_fixed_ref<'a>(v: &'a [$S, ..$n]) -> &'a $Self<$S> {
+            fn from_fixed_ref<'a>(v: &'a [$S; $n]) -> &'a $Self<$S> {
                 unsafe { mem::transmute(v) }
             }
 
             #[inline]
-            fn from_fixed_mut<'a>(v: &'a mut [$S, ..$n]) -> &'a mut $Self<$S> {
+            fn from_fixed_mut<'a>(v: &'a mut [$S; $n]) -> &'a mut $Self<$S> {
                 unsafe { mem::transmute(v) }
             }
         }


### PR DESCRIPTION
[Ops were removed from the prelude](https://github.com/rust-lang/rust/commit/56290a004493a5d2e211f056601533253497df60), [`Sized` is no longer implied for `Self`](https://github.com/rust-lang/rfcs/pull/546), and [the fixed orphan check](https://github.com/nikomatsakis/rust/commit/c61a0092bc) seems to have broken `#[derive(RustcEncodable, RustcDecodable)` somehow. Added op imports, sized bounds, and the `old_orphan_check` feature to fix these problems.