### PR TITLE
Update rust

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -541,8 +541,6 @@ impl<S> Index<usize> for Matrix2<S> {
 }
 
 impl<S> IndexMut<usize> for Matrix2<S> {
-    type Output =  Vector2<S>;
-
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &usize) -> &'a mut Vector2<S> {
         FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[*i])
@@ -625,8 +623,6 @@ impl<S> Index<usize> for Matrix3<S> {
 }
 
 impl<S> IndexMut<usize> for Matrix3<S> {
-    type Output = Vector3<S>;
-
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &usize) -> &'a mut Vector3<S> {
         FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[*i])
@@ -714,8 +710,6 @@ impl<S> Index<usize> for Matrix4<S> {
 }
 
 impl<S> IndexMut<usize> for Matrix4<S> {
-    type Output = Vector4<S>;
-
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &usize) -> &'a mut Vector4<S> {
         FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[*i])

--- a/src/point.rs
+++ b/src/point.rs
@@ -144,7 +144,6 @@ impl<S: BaseNum> Index<usize> for Point2<S> {
 }
 
 impl<S: BaseNum> IndexMut<usize> for Point2<S> {
-    type Output = S;
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &usize) -> &'a mut S {
         &mut self.as_mut_fixed()[*i]
@@ -301,8 +300,6 @@ impl<S: BaseNum> Index<usize> for Point3<S> {
 }
 
 impl<S: BaseNum> IndexMut<usize> for Point3<S> {
-    type Output = S;
-
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &usize) -> &'a mut S {
         &mut self.as_mut_fixed()[*i]

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -61,8 +61,6 @@ impl<S: BaseFloat> Index<usize> for Quaternion<S> {
 }
 
 impl<S: BaseFloat> IndexMut<usize> for Quaternion<S> {
-    type Output = S;
-
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &usize) -> &'a mut S {
         let slice: &'a mut [S; 4] = unsafe { mem::transmute(self) };
@@ -363,7 +361,7 @@ impl<S: BaseFloat> ToMatrix4<S> for Quaternion<S> {
 
 impl<S: BaseFloat> Neg for Quaternion<S> {
     type Output = Quaternion<S>;
- 
+
     #[inline]
     fn neg(self) -> Quaternion<S> {
         Quaternion::from_sv(-self.s, -self.v)

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -267,8 +267,6 @@ macro_rules! vec(
         }
 
         impl<$S: Copy> IndexMut<usize> for $Self<$S> {
-            type Output = S;
-
             #[inline]
             fn index_mut<'a>(&'a mut self, i: &usize) -> &'a mut $S {
                 &mut self.as_mut_fixed()[*i]


### PR DESCRIPTION
`Output` is not a member of trait `IndexMut` anymore.