### PR TITLE
Rust version up

### DIFF
--- a/src/cgmath.rs
+++ b/src/cgmath.rs
@@ -16,6 +16,7 @@
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![feature(old_impl_check, plugin, core, std_misc)]
+#![plugin(rand_macros)]
 
 //! Computer graphics-centric math.
 //!
@@ -33,9 +34,6 @@
 
 extern crate "rustc-serialize" as rustc_serialize;
 extern crate rand;
-#[plugin]
-#[no_link]
-extern crate rand_macros;
 
 // Re-exports
 

--- a/src/cgmath.rs
+++ b/src/cgmath.rs
@@ -15,7 +15,7 @@
 
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![feature(old_impl_check, plugin, core, std_misc)]
+#![feature(old_impl_check, plugin, core, hash, std_misc)]
 #![plugin(rand_macros)]
 
 //! Computer graphics-centric math.


### PR DESCRIPTION
Fixes compile error. `#[plugin] extern crate rand_macros;` is deprecated now.