### PR TITLE
Remove dependencies to rand and rand_macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,3 @@ name = "cgmath"
 
 [dependencies]
 rustc-serialize="*"
-rand_macros="*"
-rand="*"

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -24,11 +24,9 @@ use approx::ApproxEq;
 use num::{BaseFloat, One, one, Zero, zero};
 
 /// An angle, in radians
-#[derive_Rand]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Hash, RustcEncodable, RustcDecodable)]
 pub struct Rad<S> { pub s: S }
 /// An angle, in degrees
-#[derive_Rand]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Hash, RustcEncodable, RustcDecodable)]
 pub struct Deg<S> { pub s: S }
 

--- a/src/cgmath.rs
+++ b/src/cgmath.rs
@@ -16,7 +16,6 @@
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![feature(old_impl_check, plugin, core, hash, std_misc)]
-#![plugin(rand_macros)]
 
 //! Computer graphics-centric math.
 //!
@@ -33,7 +32,6 @@
 //! These are provided for convenience.
 
 extern crate "rustc-serialize" as rustc_serialize;
-extern crate rand;
 
 // Re-exports
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -30,17 +30,14 @@ use vector::{Vector, EuclideanVector};
 use vector::{Vector2, Vector3, Vector4};
 
 /// A 2 x 2, column major matrix
-#[derive_Rand]
 #[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Matrix2<S> { pub x: Vector2<S>, pub y: Vector2<S> }
 
 /// A 3 x 3, column major matrix
-#[derive_Rand]
 #[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Matrix3<S> { pub x: Vector3<S>, pub y: Vector3<S>, pub z: Vector3<S> }
 
 /// A 4 x 4, column major matrix
-#[derive_Rand]
 #[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Matrix4<S> { pub x: Vector4<S>, pub y: Vector4<S>, pub z: Vector4<S>, pub w: Vector4<S> }
 

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -30,7 +30,6 @@ use vector::{Vector3, Vector, EuclideanVector};
 
 /// A [quaternion](https://en.wikipedia.org/wiki/Quaternion) in scalar/vector
 /// form.
-#[derive_Rand]
 #[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Quaternion<S> { pub s: S, pub v: Vector3<S> }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -178,7 +178,6 @@ pub trait Vector<S: BaseNum>: Array1<S> + Zero + One + Neg<Output=Self> {
 // Utility macro for generating associated functions for the vectors
 macro_rules! vec(
     ($Self_:ident <$S:ident> { $($field:ident),+ }, $n:expr, $constructor:ident) => (
-        #[derive_Rand]
         #[derive(PartialEq, Eq, Copy, Clone, Hash, RustcEncodable, RustcDecodable)]
         pub struct $Self_<S> { $(pub $field: S),+ }
 


### PR DESCRIPTION
`rand_macros` won't be available for Rust 1.0 and seems to break twice a week. I propose to just remove these trait implementations.
