### PR TITLE
Redesigned ToComponents to avoid the associated type

### DIFF
--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -20,11 +20,11 @@ use cgmath::*;
 
 #[test]
 fn test_invert() {
-	let v = Vector3::new(1.0f64, 2.0f64, 3.0f64);
+	let v = Vector3::new(1.0f64, 2.0, 3.0);
 	let t = Decomposed {
         scale: 1.5f64,
         rot: Quaternion::new(0.5f64,0.5,0.5,0.5),
-        disp: Vector3::new(6.0f64,-7.0f64,8.0)
+        disp: Vector3::new(6.0f64,-7.0,8.0)
     };
 	let ti = t.invert().expect("Expected successful inversion");
 	let vt = t.transform_vector( &v );
@@ -33,12 +33,12 @@ fn test_invert() {
 
 #[test]
 fn test_look_at() {
-	let eye = Point3::new(0.0f64, 0.0f64, -5.0f64);
-	let center = Point3::new(0.0f64, 0.0f64, 0.0f64);
-	let up = Vector3::new(1.0f64, 0.0f64, 0.0f64);
+	let eye = Point3::new(0.0f64, 0.0, -5.0);
+	let center = Point3::new(0.0f64, 0.0, 0.0);
+	let up = Vector3::new(1.0f64, 0.0, 0.0);
 	let t: Decomposed<f64,Vector3<f64>,Quaternion<f64>> = Transform::look_at(&eye, &center, &up);
-	let point = Point3::new(1.0f64, 0.0f64, 0.0f64);
-	let view_point = Point3::new(0.0f64, 1.0f64, 5.0f64);
+	let point = Point3::new(1.0f64, 0.0, 0.0);
+	let view_point = Point3::new(0.0f64, 1.0, 5.0);
 	assert!( t.transform_point(&point).approx_eq(&view_point) );
 }
 
@@ -47,9 +47,10 @@ fn test_components() {
 	let t = Decomposed {
         scale: 1.5f64,
         rot: Quaternion::new(0.5f64,0.5,0.5,0.5),
-        disp: Vector3::new(6.0f64,-7.0f64,8.0)
+        disp: Vector3::new(6.0f64,-7.0,8.0)
     };
-    assert_eq!(t.to_translation(), t.disp);
-    assert_eq!(t.to_rotation(), t.rot);
-    assert_eq!(t.to_scale(), Vector::from_value(t.scale));
+    let (scale, rot, disp) = t.decompose();
+    assert_eq!(scale, Vector::from_value(t.scale));
+    assert_eq!(rot, t.rot);
+    assert_eq!(disp, t.disp);
 }


### PR DESCRIPTION
The new design avoids `Rotation` associated type, because it was impossible to restrict it better for more defined `ToComponents2` and `ToComponents3`.

Also found out that `ToComponents` implementation for `AffineMatrix3` was not correct. Removed it until I'm able to get a proper one.