### PR TITLE
Remove old_impl_check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![feature(old_impl_check, plugin, core, std_misc, custom_derive)]
+#![feature(plugin, core, std_misc, custom_derive)]
 
 //! Computer graphics-centric math.
 //!

--- a/src/line.rs
+++ b/src/line.rs
@@ -15,28 +15,35 @@
 
 //! Line segments
 
+use std::marker::PhantomData;
 use num::{BaseNum, BaseFloat, Zero, zero, One, one};
 use point::{Point, Point2, Point3};
-use vector::{Vector, Vector2};
+use vector::{Vector, Vector2, Vector3};
 use ray::{Ray2};
 use intersect::Intersect;
 
 /// A generic directed line segment from `origin` to `dest`.
 #[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
-pub struct Line<P> {
+pub struct Line<S, V, P> {
     pub origin: P,
     pub dest: P,
+    phantom_s: PhantomData<S>,
+    phantom_v: PhantomData<V>
 }
 
-#[old_impl_check]
-impl<S: BaseNum, V: Vector<S>, P: Point<S, V>>  Line<P> {
-    pub fn new(origin: P, dest: P) -> Line<P> {
-        Line { origin:origin, dest:dest }
+impl<S: BaseNum, V: Vector<S>, P: Point<S, V>>  Line<S, V, P> {
+    pub fn new(origin: P, dest: P) -> Line<S, V, P> {
+        Line {
+            origin: origin,
+            dest: dest,
+            phantom_v: PhantomData,
+            phantom_s: PhantomData
+        }
     }
 }
 
-pub type Line2<S> = Line<Point2<S>>;
-pub type Line3<S> = Line<Point3<S>>;
+pub type Line2<S> = Line<S, Vector2<S>, Point2<S>>;
+pub type Line3<S> = Line<S, Vector3<S>, Point3<S>>;
 
 /// Determines if an intersection between a ray and a line segment is found.
 impl<S: BaseFloat> Intersect<Option<Point2<S>>> for (Ray2<S>, Line2<S>) {

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::marker::PhantomData;
 use num::BaseNum;
 use point::{Point, Point2, Point3};
 use vector::{Vector, Vector2, Vector3};
@@ -20,17 +21,21 @@ use vector::{Vector, Vector2, Vector3};
 /// A generic ray starting at `origin` and extending infinitely in
 /// `direction`.
 #[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
-pub struct Ray<P,V> {
+pub struct Ray<S, P, V> {
     pub origin: P,
     pub direction: V,
+    phantom_s: PhantomData<S>
 }
 
-#[old_impl_check]
-impl<S: BaseNum, V: Vector<S>, P: Point<S, V>> Ray<P, V> {
-    pub fn new(origin: P, direction: V) -> Ray<P,V> {
-        Ray { origin: origin, direction: direction }
+impl<S: BaseNum, V: Vector<S>, P: Point<S, V>> Ray<S, P, V> {
+    pub fn new(origin: P, direction: V) -> Ray<S, P, V> {
+        Ray {
+        	origin: origin,
+        	direction: direction,
+        	phantom_s: PhantomData
+        }
     }
 }
 
-pub type Ray2<S> = Ray<Point2<S>, Vector2<S>>;
-pub type Ray3<S> = Ray<Point3<S>, Vector3<S>>;
+pub type Ray2<S> = Ray<S, Point2<S>, Vector2<S>>;
+pub type Ray3<S> = Ray<S, Point3<S>, Vector3<S>>;

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -49,7 +49,7 @@ pub trait Rotation<S: BaseNum, V: Vector<S>, P: Point<S, V>>: PartialEq + Approx
 
     /// Rotate a ray using this rotation.
     #[inline]
-    fn rotate_ray(&self, ray: &Ray<P, V>) -> Ray<P,V> {
+    fn rotate_ray(&self, ray: &Ray<S, P, V>) -> Ray<S, P,V> {
         Ray::new(ray.origin.clone(), self.rotate_vector(&ray.direction))
     }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -44,7 +44,7 @@ pub trait Transform<S: BaseNum, V: Vector<S>, P: Point<S, V>>: Sized + PhantomFn
 
     /// Transform a ray using this transform.
     #[inline]
-    fn transform_ray(&self, ray: &Ray<P,V>) -> Ray<P, V> {
+    fn transform_ray(&self, ray: &Ray<S, P,V>) -> Ray<S, P, V> {
         Ray::new(self.transform_point(&ray.origin), self.transform_vector(&ray.direction))
     }
 


### PR DESCRIPTION
This is a _huge_ kludge to limp a little further with this library before someone actually migrates it to Associated types.