### PR TITLE
Get cgmath building in beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
 script:
   - cargo build
   - cargo test
-  - cargo bench
   - cargo doc
 after_script:
   # the doc directory needs to be in the root for rust-ci

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -17,7 +17,7 @@
 
 use std::fmt;
 use std::f64;
-use std::num::cast;
+use rust_num::traits::cast;
 use std::ops::*;
 
 use rand::{Rand, Rng};
@@ -276,10 +276,11 @@ impl<S: BaseFloat> One for Deg<S> {
     fn one() -> Deg<S> { deg(one()) }
 }
 
+const PI_2: f64 = f64::consts::PI * 2f64;
 impl<S: BaseFloat>
 Angle<S> for Rad<S> {
     #[inline] fn from<A: Angle<S>>(theta: A) -> Rad<S> { theta.to_rad() }
-    #[inline] fn full_turn() -> Rad<S> { rad(cast(f64::consts::PI_2).unwrap()) }
+    #[inline] fn full_turn() -> Rad<S> { rad(cast(PI_2).unwrap()) }
 }
 
 impl<S: BaseFloat>

--- a/src/approx.rs
+++ b/src/approx.rs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::num::{NumCast, cast};
 use rust_num::Float;
+use rust_num::traits::{NumCast, cast};
 
 pub trait ApproxEq<T: NumCast + Float>: Sized {
     fn approx_epsilon(_hack: Option<Self>) -> T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![feature(plugin, core, custom_derive)]
 
 //! Computer graphics-centric math.
 //!

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -17,12 +17,12 @@
 
 use std::fmt;
 use std::mem;
-use std::num::cast;
 use std::ops::*;
 
 use rand::{Rand, Rng};
 
 use rust_num::{Zero, zero, One, one};
+use rust_num::traits::cast;
 
 use angle::{Rad, sin, cos, sin_cos};
 use approx::ApproxEq;

--- a/src/num.rs
+++ b/src/num.rs
@@ -17,7 +17,7 @@ use approx::ApproxEq;
 
 use std::cmp;
 use std::fmt;
-use std::num::NumCast;
+use rust_num::traits::NumCast;
 
 use rust_num::{Float, Num};
 

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::num::cast;
+use rust_num::traits::cast;
 
 use rust_num::{zero, one};
 

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -16,11 +16,11 @@
 use std::f64;
 use std::fmt;
 use std::mem;
-use std::num::cast;
 use std::ops::*;
 
 use rand::{Rand, Rng};
 use rust_num::{Float, one, zero};
+use rust_num::traits::cast;
 
 use angle::{Angle, Rad, acos, sin, sin_cos, rad};
 use approx::ApproxEq;
@@ -242,7 +242,7 @@ impl<S: BaseFloat> Quaternion<S> {
     /// - [Arcsynthesis OpenGL tutorial]
     ///   (http://www.arcsynthesis.org/gltut/Positioning/Tut08%20Interpolation.html)
     pub fn slerp(&self, other: &Quaternion<S>, amount: S) -> Quaternion<S> {
-        use std::num::cast;
+        use rust_num::traits::cast;
 
         let dot = self.dot(other);
         let dot_threshold = cast(0.9995f64).unwrap();

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -133,7 +133,6 @@ pub trait Rotation3<S: BaseNum>: Rotation<S, Vector3<S>, Point3<S>>
 /// matrix:
 ///
 /// ```no_run
-/// #![feature(core)]
 /// use cgmath::rad;
 /// use cgmath::Vector2;
 /// use cgmath::{Matrix, ToMatrix2};

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use std::fmt;
+use std::marker::PhantomFn;
 
 use rust_num::{zero, one};
 
@@ -237,7 +238,10 @@ impl<S: BaseFloat + 'static> Transform3<S> for AffineMatrix3<S> {}
 
 /// A trait that allows extracting components (rotation, translation, scale)
 /// from an arbitrary transformations
-pub trait ToComponents<S, V: Vector<S>, P: Point<S, V>, R: Rotation<S, V, P>> {
+// PhantomFn works around a beta bug in deteriming the usage of S/P, and should be safely removed
+// when PhantomFn deprecation lands in stable.
+pub trait ToComponents<S: BaseNum, V: Vector<S>, P: Point<S, V>, R: Rotation<S, V, P>> 
+    : PhantomFn<S> + PhantomFn<P> {
     /// Extract the (scale, rotation, translation) triple
     fn decompose(&self) -> (V, R, V);
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -98,7 +98,7 @@
 
 use std::fmt;
 use std::mem;
-use std::num::NumCast;
+use rust_num::traits::NumCast;
 use std::ops::*;
 
 use rand::{Rand, Rng};


### PR DESCRIPTION
@kvark did all the hard work. This just finishes the `rust_num` replacement of `std::num`, and works around a compiler bug with temporary use of `PhantomFn` on `ToComponents`.

In addition, I've removed `cargo bench` from the travis config temporarily, since there's no stable support for bench yet. If there's an intent to merge this into mainline before bench stabilizes, we should probably instead put all the bench code behind a feature gate so it will run in nightly but not stable.