### PR TITLE
Implemented from_fixed() on Matrix2/3/4

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -557,7 +557,7 @@ impl<S: BaseFloat> One for Matrix4<S> {
     #[inline] fn one() -> Matrix4<S> { Matrix4::identity() }
 }
 
-impl<S> FixedArray<[[S; 2]; 2]> for Matrix2<S> {
+impl<S: Copy> FixedArray<[[S; 2]; 2]> for Matrix2<S> {
     #[inline]
     fn into_fixed(self) -> [[S; 2]; 2] {
         match self {
@@ -580,13 +580,10 @@ impl<S> FixedArray<[[S; 2]; 2]> for Matrix2<S> {
 
     #[inline]
     fn from_fixed(_v: [[S; 2]; 2]) -> Matrix2<S> {
-        // match v {
-        //     [x, y] => Matrix2 {
-        //         x: FixedArray::from_fixed(x),
-        //         y: FixedArray::from_fixed(y),
-        //     },
-        // }
-        panic!("Unimplemented, pending a fix for rust-lang/rust#16418");
+        Matrix2 {
+            x: FixedArray::from_fixed(_v[0]),
+            y: FixedArray::from_fixed(_v[1]),
+        }
     }
 
     #[inline]
@@ -600,7 +597,7 @@ impl<S> FixedArray<[[S; 2]; 2]> for Matrix2<S> {
     }
 }
 
-impl<S> Index<usize> for Matrix2<S> {
+impl<S: Copy> Index<usize> for Matrix2<S> {
     type Output =  Vector2<S>;
 
     #[inline]
@@ -609,7 +606,7 @@ impl<S> Index<usize> for Matrix2<S> {
     }
 }
 
-impl<S> IndexMut<usize> for Matrix2<S> {
+impl<S: Copy> IndexMut<usize> for Matrix2<S> {
     #[inline]
     fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut Vector2<S> {
         FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[i])
@@ -637,7 +634,7 @@ impl<S: Copy + 'static> Array2<Vector2<S>, Vector2<S>, S> for Matrix2<S> {
     }
 }
 
-impl<S> FixedArray<[[S; 3]; 3]> for Matrix3<S> {
+impl<S: Copy> FixedArray<[[S; 3]; 3]> for Matrix3<S> {
     #[inline]
     fn into_fixed(self) -> [[S; 3]; 3] {
         match self {
@@ -661,14 +658,11 @@ impl<S> FixedArray<[[S; 3]; 3]> for Matrix3<S> {
 
     #[inline]
     fn from_fixed(_v: [[S; 3]; 3]) -> Matrix3<S> {
-        // match v {
-        //     [x, y, z] => Matrix3 {
-        //         x: FixedArray::from_fixed(x),
-        //         y: FixedArray::from_fixed(y),
-        //         z: FixedArray::from_fixed(z),
-        //     },
-        // }
-        panic!("Unimplemented, pending a fix for rust-lang/rust#16418")
+        Matrix3 {
+            x: FixedArray::from_fixed(_v[0]),
+            y: FixedArray::from_fixed(_v[1]),
+            z: FixedArray::from_fixed(_v[2]),
+        }
     }
 
     #[inline]
@@ -682,7 +676,7 @@ impl<S> FixedArray<[[S; 3]; 3]> for Matrix3<S> {
     }
 }
 
-impl<S> Index<usize> for Matrix3<S> {
+impl<S: Copy> Index<usize> for Matrix3<S> {
     type Output = Vector3<S>;
 
     #[inline]
@@ -691,7 +685,7 @@ impl<S> Index<usize> for Matrix3<S> {
     }
 }
 
-impl<S> IndexMut<usize> for Matrix3<S> {
+impl<S: Copy> IndexMut<usize> for Matrix3<S> {
     #[inline]
     fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut Vector3<S> {
         FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[i])
@@ -722,7 +716,7 @@ impl<S: Copy + 'static> Array2<Vector3<S>, Vector3<S>, S> for Matrix3<S> {
     }
 }
 
-impl<S> FixedArray<[[S; 4]; 4]> for Matrix4<S> {
+impl<S: Copy> FixedArray<[[S; 4]; 4]> for Matrix4<S> {
     #[inline]
     fn into_fixed(self) -> [[S; 4]; 4] {
         match self {
@@ -747,15 +741,12 @@ impl<S> FixedArray<[[S; 4]; 4]> for Matrix4<S> {
 
     #[inline]
     fn from_fixed(_v: [[S; 4]; 4]) -> Matrix4<S> {
-        // match v {
-        //     [x, y, z, w] => Matrix4 {
-        //         x: FixedArray::from_fixed(x),
-        //         y: FixedArray::from_fixed(y),
-        //         z: FixedArray::from_fixed(z),
-        //         w: FixedArray::from_fixed(w),
-        //     },
-        // }
-        panic!("Unimplemented, pending a fix for rust-lang/rust#16418")
+        Matrix4 {
+            x: FixedArray::from_fixed(_v[0]),
+            y: FixedArray::from_fixed(_v[1]),
+            z: FixedArray::from_fixed(_v[2]),
+            w: FixedArray::from_fixed(_v[3]),
+        }
     }
 
     #[inline]
@@ -769,7 +760,7 @@ impl<S> FixedArray<[[S; 4]; 4]> for Matrix4<S> {
     }
 }
 
-impl<S> Index<usize> for Matrix4<S> {
+impl<S: Copy> Index<usize> for Matrix4<S> {
     type Output = Vector4<S>;
 
     #[inline]
@@ -778,7 +769,7 @@ impl<S> Index<usize> for Matrix4<S> {
     }
 }
 
-impl<S> IndexMut<usize> for Matrix4<S> {
+impl<S: Copy> IndexMut<usize> for Matrix4<S> {
     #[inline]
     fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut Vector4<S> {
         FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[i])

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -102,7 +102,7 @@ impl<S: BaseFloat> Matrix2<S> {
     }
 }
 
-impl<S: Copy + Neg<Output = S>> Matrix2<S> {
+impl<S: BaseFloat + Neg<Output = S>> Matrix2<S> {
     /// Negate this `Matrix2` in-place.
     #[inline]
     pub fn neg_self(&mut self) {
@@ -234,7 +234,7 @@ impl<S: BaseFloat> Matrix3<S> {
     }
 }
 
-impl<S: Copy + Neg<Output = S>> Matrix3<S> {
+impl<S: BaseFloat + Neg<Output = S>> Matrix3<S> {
     /// Negate this `Matrix3` in-place.
     #[inline]
     pub fn neg_self(&mut self) {
@@ -312,7 +312,7 @@ impl<S: BaseFloat> Matrix4<S> {
     }
 }
 
-impl<S: Copy + Neg<Output = S>> Matrix4<S> {
+impl<S: BaseFloat + Neg<Output = S>> Matrix4<S> {
     /// Negate this `Matrix4` in-place.
     #[inline]
     pub fn neg_self(&mut self) {
@@ -557,7 +557,7 @@ impl<S: BaseFloat> One for Matrix4<S> {
     #[inline] fn one() -> Matrix4<S> { Matrix4::identity() }
 }
 
-impl<S: Copy> FixedArray<[[S; 2]; 2]> for Matrix2<S> {
+impl<S: BaseFloat> FixedArray<[[S; 2]; 2]> for Matrix2<S> {
     #[inline]
     fn into_fixed(self) -> [[S; 2]; 2] {
         match self {
@@ -597,7 +597,7 @@ impl<S: Copy> FixedArray<[[S; 2]; 2]> for Matrix2<S> {
     }
 }
 
-impl<S: Copy> Index<usize> for Matrix2<S> {
+impl<S: BaseFloat> Index<usize> for Matrix2<S> {
     type Output =  Vector2<S>;
 
     #[inline]
@@ -606,14 +606,14 @@ impl<S: Copy> Index<usize> for Matrix2<S> {
     }
 }
 
-impl<S: Copy> IndexMut<usize> for Matrix2<S> {
+impl<S: BaseFloat> IndexMut<usize> for Matrix2<S> {
     #[inline]
     fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut Vector2<S> {
         FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[i])
     }
 }
 
-impl<S: Copy + 'static> Array2<Vector2<S>, Vector2<S>, S> for Matrix2<S> {
+impl<S: BaseFloat + 'static> Array2<Vector2<S>, Vector2<S>, S> for Matrix2<S> {
     #[inline]
     fn row(&self, r: usize) -> Vector2<S> {
         Vector2::new(self[0][r],
@@ -634,7 +634,7 @@ impl<S: Copy + 'static> Array2<Vector2<S>, Vector2<S>, S> for Matrix2<S> {
     }
 }
 
-impl<S: Copy> FixedArray<[[S; 3]; 3]> for Matrix3<S> {
+impl<S: BaseFloat> FixedArray<[[S; 3]; 3]> for Matrix3<S> {
     #[inline]
     fn into_fixed(self) -> [[S; 3]; 3] {
         match self {
@@ -676,7 +676,7 @@ impl<S: Copy> FixedArray<[[S; 3]; 3]> for Matrix3<S> {
     }
 }
 
-impl<S: Copy> Index<usize> for Matrix3<S> {
+impl<S: BaseFloat> Index<usize> for Matrix3<S> {
     type Output = Vector3<S>;
 
     #[inline]
@@ -685,14 +685,14 @@ impl<S: Copy> Index<usize> for Matrix3<S> {
     }
 }
 
-impl<S: Copy> IndexMut<usize> for Matrix3<S> {
+impl<S: BaseFloat> IndexMut<usize> for Matrix3<S> {
     #[inline]
     fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut Vector3<S> {
         FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[i])
     }
 }
 
-impl<S: Copy + 'static> Array2<Vector3<S>, Vector3<S>, S> for Matrix3<S> {
+impl<S: BaseFloat + 'static> Array2<Vector3<S>, Vector3<S>, S> for Matrix3<S> {
     #[inline]
     fn row(&self, r: usize) -> Vector3<S> {
         Vector3::new(self[0][r],
@@ -716,7 +716,7 @@ impl<S: Copy + 'static> Array2<Vector3<S>, Vector3<S>, S> for Matrix3<S> {
     }
 }
 
-impl<S: Copy> FixedArray<[[S; 4]; 4]> for Matrix4<S> {
+impl<S: BaseFloat> FixedArray<[[S; 4]; 4]> for Matrix4<S> {
     #[inline]
     fn into_fixed(self) -> [[S; 4]; 4] {
         match self {
@@ -760,7 +760,7 @@ impl<S: Copy> FixedArray<[[S; 4]; 4]> for Matrix4<S> {
     }
 }
 
-impl<S: Copy> Index<usize> for Matrix4<S> {
+impl<S: BaseFloat> Index<usize> for Matrix4<S> {
     type Output = Vector4<S>;
 
     #[inline]
@@ -769,14 +769,14 @@ impl<S: Copy> Index<usize> for Matrix4<S> {
     }
 }
 
-impl<S: Copy> IndexMut<usize> for Matrix4<S> {
+impl<S: BaseFloat> IndexMut<usize> for Matrix4<S> {
     #[inline]
     fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut Vector4<S> {
         FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[i])
     }
 }
 
-impl<S: Copy + 'static> Array2<Vector4<S>, Vector4<S>, S> for Matrix4<S> {
+impl<S: BaseFloat + 'static> Array2<Vector4<S>, Vector4<S>, S> for Matrix4<S> {
     #[inline]
     fn row(&self, r: usize) -> Vector4<S> {
         Vector4::new(self[0][r],
@@ -1392,7 +1392,7 @@ impl<S: BaseFloat> From<Matrix3<S>> for Quaternion<S> {
     }
 }
 
-impl<S: BaseNum> fmt::Debug for Matrix2<S> {
+impl<S: BaseNum + BaseFloat> fmt::Debug for Matrix2<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[[{:?}, {:?}], [{:?}, {:?}]]",
                 self[0][0], self[0][1],
@@ -1400,7 +1400,7 @@ impl<S: BaseNum> fmt::Debug for Matrix2<S> {
     }
 }
 
-impl<S: BaseNum> fmt::Debug for Matrix3<S> {
+impl<S: BaseNum + BaseFloat> fmt::Debug for Matrix3<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[[{:?}, {:?}, {:?}], [{:?}, {:?}, {:?}], [{:?}, {:?}, {:?}]]",
                 self[0][0], self[0][1], self[0][2],
@@ -1409,7 +1409,7 @@ impl<S: BaseNum> fmt::Debug for Matrix3<S> {
     }
 }
 
-impl<S: BaseNum> fmt::Debug for Matrix4<S> {
+impl<S: BaseNum + BaseFloat> fmt::Debug for Matrix4<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[[{:?}, {:?}, {:?}, {:?}], [{:?}, {:?}, {:?}, {:?}], [{:?}, {:?}, {:?}, {:?}], [{:?}, {:?}, {:?}, {:?}]]",
                 self[0][0], self[0][1], self[0][2], self[0][3],

--- a/src/num.rs
+++ b/src/num.rs
@@ -110,7 +110,7 @@ impl BaseInt for u64 {}
 impl BaseInt for usize {}
 
 /// Base floating point types
-pub trait BaseFloat : BaseNum + Float + ApproxEq<Self> {}
+pub trait BaseFloat : BaseNum + Float + Copy + ApproxEq<Self> {}
 
 impl BaseFloat for f32 {}
 impl BaseFloat for f64 {}


### PR DESCRIPTION
It required adding Copy to the type, but BaseFloat is only implemented for f32 and f64, which are both Copy-able, so it shouldn't affect anything.  Also, Copy is used in other parts, so again, shouldn't affect anything.

Wasn't able to use the match statement, since it's marked as experimental, but just doing a normal index access works well enough.