### PR TITLE
Remove FixedArray trait in favour of std::convert

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -90,14 +90,3 @@ pub trait Array2<Column: Array1<Element>+'static, Row: Array1<Element>, Element:
     fn map<F>(&mut self, op: F) -> Self
         where F: FnMut(&Column) -> Column;
 }
-
-/// Homogeneous arrays of elements that can be converted to and from `[T, ..N]`
-/// arrays.
-pub trait FixedArray<V> {
-    fn into_fixed(self) -> V;
-    fn as_fixed<'a>(&'a self) -> &'a V;
-    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut V;
-    fn from_fixed(v: V) -> Self;
-    fn from_fixed_ref<'a>(v: &'a V) -> &'a Self;
-    fn from_fixed_mut<'a>(v: &'a mut V) -> &'a mut Self;
-}

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1142,30 +1142,42 @@ impl<S: BaseFloat> ApproxEq<S> for Matrix4<S> {
 }
 
 macro_rules! index_operators {
-    ($MatrixN:ident <$S:ident>, $VectorN: ident, $n:expr) => {
-        impl<$S> Index<usize> for $MatrixN<$S> {
-            type Output = $VectorN<$S>;
+    ($MatrixN:ident<$S:ident>, $n:expr, $Output:ty, $I:ty) => {
+        impl<$S> Index<$I> for $MatrixN<$S> {
+            type Output = $Output;
 
             #[inline]
-            fn index<'a>(&'a self, i: usize) -> &'a $VectorN<$S> {
+            fn index<'a>(&'a self, i: $I) -> &'a $Output {
                 let v: &[[$S; $n]; $n] = self.as_ref();
                 From::from(&v[i])
             }
         }
 
-        impl<$S> IndexMut<usize> for $MatrixN<$S> {
+        impl<$S> IndexMut<$I> for $MatrixN<$S> {
             #[inline]
-            fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut $VectorN<$S> {
+            fn index_mut<'a>(&'a mut self, i: $I) -> &'a mut $Output {
                 let v: &mut [[$S; $n]; $n] = self.as_mut();
                 From::from(&mut v[i])
             }
         }
-    };
+    }
 }
 
-index_operators!(Matrix2<S>, Vector2, 2);
-index_operators!(Matrix3<S>, Vector3, 3);
-index_operators!(Matrix4<S>, Vector4, 4);
+index_operators!(Matrix2<S>, 2, Vector2<S>, usize);
+index_operators!(Matrix3<S>, 3, Vector3<S>, usize);
+index_operators!(Matrix4<S>, 4, Vector4<S>, usize);
+// index_operators!(Matrix2<S>, 2, [Vector2<S>], Range<usize>);
+// index_operators!(Matrix3<S>, 3, [Vector3<S>], Range<usize>);
+// index_operators!(Matrix4<S>, 4, [Vector4<S>], Range<usize>);
+// index_operators!(Matrix2<S>, 2, [Vector2<S>], RangeTo<usize>);
+// index_operators!(Matrix3<S>, 3, [Vector3<S>], RangeTo<usize>);
+// index_operators!(Matrix4<S>, 4, [Vector4<S>], RangeTo<usize>);
+// index_operators!(Matrix2<S>, 2, [Vector2<S>], RangeFrom<usize>);
+// index_operators!(Matrix3<S>, 3, [Vector3<S>], RangeFrom<usize>);
+// index_operators!(Matrix4<S>, 4, [Vector4<S>], RangeFrom<usize>);
+// index_operators!(Matrix2<S>, 2, [Vector2<S>], RangeFull);
+// index_operators!(Matrix3<S>, 3, [Vector3<S>], RangeFull);
+// index_operators!(Matrix4<S>, 4, [Vector4<S>], RangeFull);
 
 macro_rules! fixed_array_conversions {
     ($MatrixN:ident <$S:ident> { $($field:ident : $index:expr),+ }, $n:expr) => {

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -26,7 +26,7 @@ use rust_num::traits::cast;
 
 use angle::{Rad, sin, cos, sin_cos};
 use approx::ApproxEq;
-use array::{Array1, Array2, FixedArray};
+use array::{Array1, Array2};
 use num::{BaseFloat, BaseNum};
 use point::{Point, Point3};
 use quaternion::Quaternion;
@@ -557,65 +557,6 @@ impl<S: BaseFloat> One for Matrix4<S> {
     #[inline] fn one() -> Matrix4<S> { Matrix4::identity() }
 }
 
-impl<S> FixedArray<[[S; 2]; 2]> for Matrix2<S> {
-    #[inline]
-    fn into_fixed(self) -> [[S; 2]; 2] {
-        match self {
-            Matrix2 { x, y } => [
-                x.into_fixed(),
-                y.into_fixed(),
-            ],
-        }
-    }
-
-    #[inline]
-    fn as_fixed<'a>(&'a self) -> &'a [[S; 2]; 2] {
-        unsafe { mem::transmute(self) }
-    }
-
-    #[inline]
-    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [[S; 2]; 2] {
-        unsafe { mem::transmute(self) }
-    }
-
-    #[inline]
-    fn from_fixed(_v: [[S; 2]; 2]) -> Matrix2<S> {
-        // match v {
-        //     [x, y] => Matrix2 {
-        //         x: FixedArray::from_fixed(x),
-        //         y: FixedArray::from_fixed(y),
-        //     },
-        // }
-        panic!("Unimplemented, pending a fix for rust-lang/rust#16418");
-    }
-
-    #[inline]
-    fn from_fixed_ref<'a>(v: &'a [[S; 2]; 2]) -> &'a Matrix2<S> {
-        unsafe { mem::transmute(v) }
-    }
-
-    #[inline]
-    fn from_fixed_mut<'a>(v: &'a mut [[S; 2]; 2]) -> &'a mut Matrix2<S> {
-        unsafe { mem::transmute(v) }
-    }
-}
-
-impl<S> Index<usize> for Matrix2<S> {
-    type Output =  Vector2<S>;
-
-    #[inline]
-    fn index<'a>(&'a self, i: usize) -> &'a Vector2<S> {
-        FixedArray::from_fixed_ref(&self.as_fixed()[i])
-    }
-}
-
-impl<S> IndexMut<usize> for Matrix2<S> {
-    #[inline]
-    fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut Vector2<S> {
-        FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[i])
-    }
-}
-
 impl<S: Copy + 'static> Array2<Vector2<S>, Vector2<S>, S> for Matrix2<S> {
     #[inline]
     fn row(&self, r: usize) -> Vector2<S> {
@@ -634,67 +575,6 @@ impl<S: Copy + 'static> Array2<Vector2<S>, Vector2<S>, S> for Matrix2<S> {
         self.x = op(&self.x);
         self.y = op(&self.y);
         *self
-    }
-}
-
-impl<S> FixedArray<[[S; 3]; 3]> for Matrix3<S> {
-    #[inline]
-    fn into_fixed(self) -> [[S; 3]; 3] {
-        match self {
-            Matrix3 { x, y, z } => [
-                x.into_fixed(),
-                y.into_fixed(),
-                z.into_fixed(),
-            ],
-        }
-    }
-
-    #[inline]
-    fn as_fixed<'a>(&'a self) -> &'a [[S; 3]; 3] {
-        unsafe { mem::transmute(self) }
-    }
-
-    #[inline]
-    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [[S; 3]; 3] {
-        unsafe { mem::transmute(self) }
-    }
-
-    #[inline]
-    fn from_fixed(_v: [[S; 3]; 3]) -> Matrix3<S> {
-        // match v {
-        //     [x, y, z] => Matrix3 {
-        //         x: FixedArray::from_fixed(x),
-        //         y: FixedArray::from_fixed(y),
-        //         z: FixedArray::from_fixed(z),
-        //     },
-        // }
-        panic!("Unimplemented, pending a fix for rust-lang/rust#16418")
-    }
-
-    #[inline]
-    fn from_fixed_ref<'a>(v: &'a [[S; 3]; 3]) -> &'a Matrix3<S> {
-        unsafe { mem::transmute(v) }
-    }
-
-    #[inline]
-    fn from_fixed_mut<'a>(v: &'a mut [[S; 3]; 3]) -> &'a mut Matrix3<S> {
-        unsafe { mem::transmute(v) }
-    }
-}
-
-impl<S> Index<usize> for Matrix3<S> {
-    type Output = Vector3<S>;
-
-    #[inline]
-    fn index<'a>(&'a self, i: usize) -> &'a Vector3<S> {
-        FixedArray::from_fixed_ref(&self.as_fixed()[i])
-    }
-}
-
-impl<S> IndexMut<usize> for Matrix3<S> {
-    #[inline]
-    fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut Vector3<S> {
-        FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[i])
     }
 }
 
@@ -719,69 +599,6 @@ impl<S: Copy + 'static> Array2<Vector3<S>, Vector3<S>, S> for Matrix3<S> {
         self.y = op(&self.y);
         self.z = op(&self.z);
         *self
-    }
-}
-
-impl<S> FixedArray<[[S; 4]; 4]> for Matrix4<S> {
-    #[inline]
-    fn into_fixed(self) -> [[S; 4]; 4] {
-        match self {
-            Matrix4 { x, y, z, w } => [
-                x.into_fixed(),
-                y.into_fixed(),
-                z.into_fixed(),
-                w.into_fixed(),
-            ],
-        }
-    }
-
-    #[inline]
-    fn as_fixed<'a>(&'a self) -> &'a [[S; 4]; 4] {
-        unsafe { mem::transmute(self) }
-    }
-
-    #[inline]
-    fn as_mut_fixed<'a>(&'a mut self) -> &'a mut [[S; 4]; 4] {
-        unsafe { mem::transmute(self) }
-    }
-
-    #[inline]
-    fn from_fixed(_v: [[S; 4]; 4]) -> Matrix4<S> {
-        // match v {
-        //     [x, y, z, w] => Matrix4 {
-        //         x: FixedArray::from_fixed(x),
-        //         y: FixedArray::from_fixed(y),
-        //         z: FixedArray::from_fixed(z),
-        //         w: FixedArray::from_fixed(w),
-        //     },
-        // }
-        panic!("Unimplemented, pending a fix for rust-lang/rust#16418")
-    }
-
-    #[inline]
-    fn from_fixed_ref<'a>(v: &'a [[S; 4]; 4]) -> &'a Matrix4<S> {
-        unsafe { mem::transmute(v) }
-    }
-
-    #[inline]
-    fn from_fixed_mut<'a>(v: &'a mut [[S; 4]; 4]) -> &'a mut Matrix4<S> {
-        unsafe { mem::transmute(v) }
-    }
-}
-
-impl<S> Index<usize> for Matrix4<S> {
-    type Output = Vector4<S>;
-
-    #[inline]
-    fn index<'a>(&'a self, i: usize) -> &'a Vector4<S> {
-        FixedArray::from_fixed_ref(&self.as_fixed()[i])
-    }
-}
-
-impl<S> IndexMut<usize> for Matrix4<S> {
-    #[inline]
-    fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut Vector4<S> {
-        FixedArray::from_fixed_mut(&mut self.as_mut_fixed()[i])
     }
 }
 
@@ -1324,7 +1141,126 @@ impl<S: BaseFloat> ApproxEq<S> for Matrix4<S> {
     }
 }
 
-// Conversion traits
+macro_rules! index_operators {
+    ($MatrixN:ident <$S:ident>, $VectorN: ident, $n:expr) => {
+        impl<$S> Index<usize> for $MatrixN<$S> {
+            type Output = $VectorN<$S>;
+
+            #[inline]
+            fn index<'a>(&'a self, i: usize) -> &'a $VectorN<$S> {
+                let v: &[[$S; $n]; $n] = self.as_ref();
+                From::from(&v[i])
+            }
+        }
+
+        impl<$S> IndexMut<usize> for $MatrixN<$S> {
+            #[inline]
+            fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut $VectorN<$S> {
+                let v: &mut [[$S; $n]; $n] = self.as_mut();
+                From::from(&mut v[i])
+            }
+        }
+    };
+}
+
+index_operators!(Matrix2<S>, Vector2, 2);
+index_operators!(Matrix3<S>, Vector3, 3);
+index_operators!(Matrix4<S>, Vector4, 4);
+
+macro_rules! fixed_array_conversions {
+    ($MatrixN:ident <$S:ident> { $($field:ident : $index:expr),+ }, $n:expr) => {
+        impl<$S> Into<[[$S; $n]; $n]> for $MatrixN<$S> {
+            #[inline]
+            fn into(self) -> [[$S; $n]; $n] {
+                match self { $MatrixN { $($field),+ } => [$($field.into()),+] }
+            }
+        }
+
+        impl<$S> AsRef<[[$S; $n]; $n]> for $MatrixN<$S> {
+            #[inline]
+            fn as_ref(&self) -> &[[$S; $n]; $n] {
+                unsafe { mem::transmute(self) }
+            }
+        }
+
+        impl<$S> AsMut<[[$S; $n]; $n]> for $MatrixN<$S> {
+            #[inline]
+            fn as_mut(&mut self) -> &mut [[$S; $n]; $n] {
+                unsafe { mem::transmute(self) }
+            }
+        }
+
+        impl<$S: Copy> From<[[$S; $n]; $n]> for $MatrixN<$S> {
+            #[inline]
+            fn from(m: [[$S; $n]; $n]) -> $MatrixN<$S> {
+                // We need to use a copy here because we can't pattern match on arrays yet
+                $MatrixN { $($field: From::from(m[$index])),+ }
+            }
+        }
+
+        impl<'a, $S> From<&'a [[$S; $n]; $n]> for &'a $MatrixN<$S> {
+            #[inline]
+            fn from(m: &'a [[$S; $n]; $n]) -> &'a $MatrixN<$S> {
+                unsafe { mem::transmute(m) }
+            }
+        }
+
+        impl<'a, $S> From<&'a mut [[$S; $n]; $n]> for &'a mut $MatrixN<$S> {
+            #[inline]
+            fn from(m: &'a mut [[$S; $n]; $n]) -> &'a mut $MatrixN<$S> {
+                unsafe { mem::transmute(m) }
+            }
+        }
+
+        // impl<$S> Into<[$S; ($n * $n)]> for $MatrixN<$S> {
+        //     #[inline]
+        //     fn into(self) -> [[$S; $n]; $n] {
+        //         // TODO: Not sure how to implement this...
+        //         unimplemented!()
+        //     }
+        // }
+
+        impl<$S> AsRef<[$S; ($n * $n)]> for $MatrixN<$S> {
+            #[inline]
+            fn as_ref(&self) -> &[$S; ($n * $n)] {
+                unsafe { mem::transmute(self) }
+            }
+        }
+
+        impl<$S> AsMut<[$S; ($n * $n)]> for $MatrixN<$S> {
+            #[inline]
+            fn as_mut(&mut self) -> &mut [$S; ($n * $n)] {
+                unsafe { mem::transmute(self) }
+            }
+        }
+
+        // impl<$S> From<[$S; ($n * $n)]> for $MatrixN<$S> {
+        //     #[inline]
+        //     fn from(m: [$S; ($n * $n)]) -> $MatrixN<$S> {
+        //         // TODO: Not sure how to implement this...
+        //         unimplemented!()
+        //     }
+        // }
+
+        impl<'a, $S> From<&'a [$S; ($n * $n)]> for &'a $MatrixN<$S> {
+            #[inline]
+            fn from(m: &'a [$S; ($n * $n)]) -> &'a $MatrixN<$S> {
+                unsafe { mem::transmute(m) }
+            }
+        }
+
+        impl<'a, $S> From<&'a mut [$S; ($n * $n)]> for &'a mut $MatrixN<$S> {
+            #[inline]
+            fn from(m: &'a mut [$S; ($n * $n)]) -> &'a mut $MatrixN<$S> {
+                unsafe { mem::transmute(m) }
+            }
+        }
+    }
+}
+
+fixed_array_conversions!(Matrix2<S> { x:0, y:1 }, 2);
+fixed_array_conversions!(Matrix3<S> { x:0, y:1, z:2 }, 3);
+fixed_array_conversions!(Matrix4<S> { x:0, y:1, z:2, w:3 }, 4);
 
 impl<S: BaseFloat> From<Matrix2<S>> for Matrix3<S> {
     /// Clone the elements of a 2-dimensional matrix into the top-left corner

--- a/src/point.rs
+++ b/src/point.rs
@@ -443,27 +443,35 @@ tuple_conversions!(Point2<S> { x, y }, (S, S));
 tuple_conversions!(Point3<S> { x, y, z }, (S, S, S));
 
 macro_rules! index_operators {
-    ($PointN:ident <$S:ident>, $n:expr) => {
-        impl<$S> Index<usize> for $PointN<$S> {
-            type Output = $S;
+    ($PointN:ident<$S:ident>, $n:expr, $Output:ty, $I:ty) => {
+        impl<$S> Index<$I> for $PointN<$S> {
+            type Output = $Output;
 
             #[inline]
-            fn index<'a>(&'a self, i: usize) -> &'a $S {
+            fn index<'a>(&'a self, i: $I) -> &'a $Output {
                 let v: &[$S; $n] = self.as_ref(); &v[i]
             }
         }
 
-        impl<$S> IndexMut<usize> for $PointN<$S> {
+        impl<$S> IndexMut<$I> for $PointN<$S> {
             #[inline]
-            fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut $S {
+            fn index_mut<'a>(&'a mut self, i: $I) -> &'a mut $Output {
                 let v: &mut [$S; $n] = self.as_mut(); &mut v[i]
             }
         }
     }
 }
 
-index_operators!(Point2<S>, 2);
-index_operators!(Point3<S>, 3);
+index_operators!(Point2<S>, 2, S, usize);
+index_operators!(Point3<S>, 3, S, usize);
+index_operators!(Point2<S>, 2, [S], Range<usize>);
+index_operators!(Point3<S>, 3, [S], Range<usize>);
+index_operators!(Point2<S>, 2, [S], RangeTo<usize>);
+index_operators!(Point3<S>, 3, [S], RangeTo<usize>);
+index_operators!(Point2<S>, 2, [S], RangeFrom<usize>);
+index_operators!(Point3<S>, 3, [S], RangeFrom<usize>);
+index_operators!(Point2<S>, 2, [S], RangeFull);
+index_operators!(Point3<S>, 3, [S], RangeFull);
 
 impl<S: BaseNum> fmt::Debug for Point2<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/point.rs
+++ b/src/point.rs
@@ -507,3 +507,85 @@ impl<S: BaseFloat + 'static> Bound<S> for Point3<S> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    mod point2 {
+        use point::*;
+
+        const POINT2: Point2<i32> = Point2 { x: 1, y: 2 };
+
+        #[test]
+        fn test_index() {
+            assert_eq!(POINT2[0], POINT2.x);
+            assert_eq!(POINT2[1], POINT2.y);
+        }
+
+        #[test]
+        fn test_index_mut() {
+            let mut p = POINT2;
+            *&mut p[0] = 0;
+            assert_eq!(p, [0, 2].into());
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_index_out_of_bounds() {
+            POINT2[2];
+        }
+
+        #[test]
+        fn test_index_range() {
+            assert_eq!(&POINT2[..0], &[]);
+            assert_eq!(&POINT2[..1], &[1]);
+            assert_eq!(POINT2[..0].len(), 0);
+            assert_eq!(POINT2[..1].len(), 1);
+            assert_eq!(&POINT2[2..], &[]);
+            assert_eq!(&POINT2[1..], &[2]);
+            assert_eq!(POINT2[2..].len(), 0);
+            assert_eq!(POINT2[1..].len(), 1);
+            assert_eq!(&POINT2[..], &[1, 2]);
+            assert_eq!(POINT2[..].len(), 2);
+        }
+    }
+
+    mod point3 {
+        use point::*;
+
+        const POINT3: Point3<i32> = Point3 { x: 1, y: 2, z: 3 };
+
+        #[test]
+        fn test_index() {
+            assert_eq!(POINT3[0], POINT3.x);
+            assert_eq!(POINT3[1], POINT3.y);
+            assert_eq!(POINT3[2], POINT3.z);
+        }
+
+        #[test]
+        fn test_index_mut() {
+            let mut p = POINT3;
+            *&mut p[1] = 0;
+            assert_eq!(p, [1, 0, 3].into());
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_index_out_of_bounds() {
+            POINT3[3];
+        }
+
+        #[test]
+        fn test_index_range() {
+            assert_eq!(&POINT3[..1], &[1]);
+            assert_eq!(&POINT3[..2], &[1, 2]);
+            assert_eq!(POINT3[..1].len(), 1);
+            assert_eq!(POINT3[..2].len(), 2);
+            assert_eq!(&POINT3[2..], &[3]);
+            assert_eq!(&POINT3[1..], &[2, 3]);
+            assert_eq!(POINT3[2..].len(), 1);
+            assert_eq!(POINT3[1..].len(), 2);
+            assert_eq!(&POINT3[..], &[1, 2, 3]);
+            assert_eq!(POINT3[..].len(), 3);
+        }
+    }
+}

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -503,21 +503,31 @@ impl<'a, S: BaseFloat> From<&'a mut (S, S, S, S)> for &'a mut Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> Index<usize> for Quaternion<S> {
-    type Output = S;
+macro_rules! index_operators {
+    ($S:ident, $Output:ty, $I:ty) => {
+        impl<$S: BaseFloat> Index<$I> for Quaternion<$S> {
+            type Output = $Output;
 
-    #[inline]
-    fn index<'a>(&'a self, i: usize) -> &'a S {
-        let v: &[S; 4] = self.as_ref(); &v[i]
+            #[inline]
+            fn index<'a>(&'a self, i: $I) -> &'a $Output {
+                let v: &[$S; 4] = self.as_ref(); &v[i]
+            }
+        }
+
+        impl<$S: BaseFloat> IndexMut<$I> for Quaternion<$S> {
+            #[inline]
+            fn index_mut<'a>(&'a mut self, i: $I) -> &'a mut $Output {
+                let v: &mut [$S; 4] = self.as_mut(); &mut v[i]
+            }
+        }
     }
 }
 
-impl<S: BaseFloat> IndexMut<usize> for Quaternion<S> {
-    #[inline]
-    fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut S {
-        let v: &mut [S; 4] = self.as_mut(); &mut v[i]
-    }
-}
+index_operators!(S, S, usize);
+index_operators!(S, [S], Range<usize>);
+index_operators!(S, [S], RangeTo<usize>);
+index_operators!(S, [S], RangeFrom<usize>);
+index_operators!(S, [S], RangeFull);
 
 impl<S: BaseFloat + Rand> Rand for Quaternion<S> {
     #[inline]

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -35,7 +35,10 @@ use vector::{Vector3, Vector, EuclideanVector};
 /// A [quaternion](https://en.wikipedia.org/wiki/Quaternion) in scalar/vector
 /// form.
 #[derive(Copy, Clone, PartialEq, RustcEncodable, RustcDecodable)]
-pub struct Quaternion<S> { pub s: S, pub v: Vector3<S> }
+pub struct Quaternion<S> {
+    pub s: S,
+    pub v: Vector3<S>,
+}
 
 impl<S: Copy + BaseFloat> Array1<S> for Quaternion<S> {
     #[inline]
@@ -45,24 +48,6 @@ impl<S: Copy + BaseFloat> Array1<S> for Quaternion<S> {
         self.v.y = op(self.v.y);
         self.v.z = op(self.v.z);
         *self
-    }
-}
-
-impl<S: BaseFloat> Index<usize> for Quaternion<S> {
-    type Output = S;
-
-    #[inline]
-    fn index<'a>(&'a self, i: usize) -> &'a S {
-        let slice: &[S; 4] = unsafe { mem::transmute(self) };
-        &slice[i]
-    }
-}
-
-impl<S: BaseFloat> IndexMut<usize> for Quaternion<S> {
-    #[inline]
-    fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut S {
-        let slice: &'a mut [S; 4] = unsafe { mem::transmute(self) };
-        &mut slice[i]
     }
 }
 
@@ -431,6 +416,106 @@ impl<S: BaseFloat> Rotation3<S> for Quaternion<S> where S: 'static {
                         s1 * s2 * c3 + c1 * c2 * s3,
                         s1 * c2 * c3 + c1 * s2 * s3,
                         c1 * s2 * c3 - s1 * c2 * s3)
+    }
+}
+
+impl<S: BaseFloat> Into<[S; 4]> for Quaternion<S> {
+    #[inline]
+    fn into(self) -> [S; 4] {
+        match self.into() { (w, xi, yj, zk) => [w, xi, yj, zk] }
+    }
+}
+
+impl<S: BaseFloat> AsRef<[S; 4]> for Quaternion<S> {
+    #[inline]
+    fn as_ref(&self) -> &[S; 4] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl<S: BaseFloat> AsMut<[S; 4]> for Quaternion<S> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [S; 4] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl<S: BaseFloat> From<[S; 4]> for Quaternion<S> {
+    #[inline]
+    fn from(v: [S; 4]) -> Quaternion<S> {
+        Quaternion::new(v[0], v[1], v[2], v[3])
+    }
+}
+
+impl<'a, S: BaseFloat> From<&'a [S; 4]> for &'a Quaternion<S> {
+    #[inline]
+    fn from(v: &'a [S; 4]) -> &'a Quaternion<S> {
+        unsafe { mem::transmute(v) }
+    }
+}
+
+impl<'a, S: BaseFloat> From<&'a mut [S; 4]> for &'a mut Quaternion<S> {
+    #[inline]
+    fn from(v: &'a mut [S; 4]) -> &'a mut Quaternion<S> {
+        unsafe { mem::transmute(v) }
+    }
+}
+
+impl<S: BaseFloat> Into<(S, S, S, S)> for Quaternion<S> {
+    #[inline]
+    fn into(self) -> (S, S, S, S) {
+        match self { Quaternion { s, v: Vector3 { x, y, z } } => (s, x, y, z) }
+    }
+}
+
+impl<S: BaseFloat> AsRef<(S, S, S, S)> for Quaternion<S> {
+    #[inline]
+    fn as_ref(&self) -> &(S, S, S, S) {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl<S: BaseFloat> AsMut<(S, S, S, S)> for Quaternion<S> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut (S, S, S, S) {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+impl<S: BaseFloat> From<(S, S, S, S)> for Quaternion<S> {
+    #[inline]
+    fn from(v: (S, S, S, S)) -> Quaternion<S> {
+        match v { (w, xi, yj, zk) => Quaternion::new(w, xi, yj, zk) }
+    }
+}
+
+impl<'a, S: BaseFloat> From<&'a (S, S, S, S)> for &'a Quaternion<S> {
+    #[inline]
+    fn from(v: &'a (S, S, S, S)) -> &'a Quaternion<S> {
+        unsafe { mem::transmute(v) }
+    }
+}
+
+impl<'a, S: BaseFloat> From<&'a mut (S, S, S, S)> for &'a mut Quaternion<S> {
+    #[inline]
+    fn from(v: &'a mut (S, S, S, S)) -> &'a mut Quaternion<S> {
+        unsafe { mem::transmute(v) }
+    }
+}
+
+impl<S: BaseFloat> Index<usize> for Quaternion<S> {
+    type Output = S;
+
+    #[inline]
+    fn index<'a>(&'a self, i: usize) -> &'a S {
+        let v: &[S; 4] = self.as_ref(); &v[i]
+    }
+}
+
+impl<S: BaseFloat> IndexMut<usize> for Quaternion<S> {
+    #[inline]
+    fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut S {
+        let v: &mut [S; 4] = self.as_mut(); &mut v[i]
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -449,28 +449,40 @@ tuple_conversions!(Vector3<S> { x, y, z }, (S, S, S));
 tuple_conversions!(Vector4<S> { x, y, z, w }, (S, S, S, S));
 
 macro_rules! index_operators {
-    ($Self_:ident <$S:ident>, $n:expr) => {
-        impl<$S> Index<usize> for $Self_<$S> {
-            type Output = $S;
+    ($VectorN:ident<$S:ident>, $n:expr, $Output:ty, $I:ty) => {
+        impl<$S> Index<$I> for $VectorN<$S> {
+            type Output = $Output;
 
             #[inline]
-            fn index<'a>(&'a self, i: usize) -> &'a $S {
+            fn index<'a>(&'a self, i: $I) -> &'a $Output {
                 let v: &[$S; $n] = self.as_ref(); &v[i]
             }
         }
 
-        impl<$S> IndexMut<usize> for $Self_<$S> {
+        impl<$S> IndexMut<$I> for $VectorN<$S> {
             #[inline]
-            fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut $S {
+            fn index_mut<'a>(&'a mut self, i: $I) -> &'a mut $Output {
                 let v: &mut [$S; $n] = self.as_mut(); &mut v[i]
             }
         }
     }
 }
 
-index_operators!(Vector2<S>, 2);
-index_operators!(Vector3<S>, 3);
-index_operators!(Vector4<S>, 4);
+index_operators!(Vector2<S>, 2, S, usize);
+index_operators!(Vector3<S>, 3, S, usize);
+index_operators!(Vector4<S>, 4, S, usize);
+index_operators!(Vector2<S>, 2, [S], Range<usize>);
+index_operators!(Vector3<S>, 3, [S], Range<usize>);
+index_operators!(Vector4<S>, 4, [S], Range<usize>);
+index_operators!(Vector2<S>, 2, [S], RangeTo<usize>);
+index_operators!(Vector3<S>, 3, [S], RangeTo<usize>);
+index_operators!(Vector4<S>, 4, [S], RangeTo<usize>);
+index_operators!(Vector2<S>, 2, [S], RangeFrom<usize>);
+index_operators!(Vector3<S>, 3, [S], RangeFrom<usize>);
+index_operators!(Vector4<S>, 4, [S], RangeFrom<usize>);
+index_operators!(Vector2<S>, 2, [S], RangeFull);
+index_operators!(Vector3<S>, 3, [S], RangeFull);
+index_operators!(Vector4<S>, 4, [S], RangeFull);
 
 /// Operations specific to numeric two-dimensional vectors.
 impl<S: BaseNum> Vector2<S> {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -347,47 +347,47 @@ vec!(Vector3<S> { x, y, z }, 3, vec3);
 vec!(Vector4<S> { x, y, z, w }, 4, vec4);
 
 macro_rules! fixed_array_conversions {
-    ($Self_:ident <$S:ident> { $($field:ident : $index:expr),+ }, $n:expr) => {
+    ($VectorN:ident <$S:ident> { $($field:ident : $index:expr),+ }, $n:expr) => {
 
-        impl<$S> Into<[$S; $n]> for $Self_<$S> {
+        impl<$S> Into<[$S; $n]> for $VectorN<$S> {
             #[inline]
             fn into(self) -> [$S; $n] {
-                match self { $Self_ { $($field),+ } => [$($field),+] }
+                match self { $VectorN { $($field),+ } => [$($field),+] }
             }
         }
 
-        impl<$S> AsRef<[$S; $n]> for $Self_<$S> {
+        impl<$S> AsRef<[$S; $n]> for $VectorN<$S> {
             #[inline]
             fn as_ref(&self) -> &[$S; $n] {
                 unsafe { mem::transmute(self) }
             }
         }
 
-        impl<$S> AsMut<[$S; $n]> for $Self_<$S> {
+        impl<$S> AsMut<[$S; $n]> for $VectorN<$S> {
             #[inline]
             fn as_mut(&mut self) -> &mut [$S; $n] {
                 unsafe { mem::transmute(self) }
             }
         }
 
-        impl<$S: Clone> From<[$S; $n]> for $Self_<$S> {
+        impl<$S: Clone> From<[$S; $n]> for $VectorN<$S> {
             #[inline]
-            fn from(v: [$S; $n]) -> $Self_<$S> {
+            fn from(v: [$S; $n]) -> $VectorN<$S> {
                 // We need to use a clone here because we can't pattern match on arrays yet
-                $Self_ { $($field: v[$index].clone()),+ }
+                $VectorN { $($field: v[$index].clone()),+ }
             }
         }
 
-        impl<'a, $S> From<&'a [$S; $n]> for &'a $Self_<$S> {
+        impl<'a, $S> From<&'a [$S; $n]> for &'a $VectorN<$S> {
             #[inline]
-            fn from(v: &'a [$S; $n]) -> &'a $Self_<$S> {
+            fn from(v: &'a [$S; $n]) -> &'a $VectorN<$S> {
                 unsafe { mem::transmute(v) }
             }
         }
 
-        impl<'a, $S> From<&'a mut [$S; $n]> for &'a mut $Self_<$S> {
+        impl<'a, $S> From<&'a mut [$S; $n]> for &'a mut $VectorN<$S> {
             #[inline]
-            fn from(v: &'a mut [$S; $n]) -> &'a mut $Self_<$S> {
+            fn from(v: &'a mut [$S; $n]) -> &'a mut $VectorN<$S> {
                 unsafe { mem::transmute(v) }
             }
         }
@@ -399,45 +399,45 @@ fixed_array_conversions!(Vector3<S> { x:0, y:1, z:2 }, 3);
 fixed_array_conversions!(Vector4<S> { x:0, y:1, z:2, w:3 }, 4);
 
 macro_rules! tuple_conversions {
-    ($Self_:ident <$S:ident> { $($field:ident),+ }, $Tuple:ty) => {
-        impl<$S> Into<$Tuple> for $Self_<$S> {
+    ($VectorN:ident <$S:ident> { $($field:ident),+ }, $Tuple:ty) => {
+        impl<$S> Into<$Tuple> for $VectorN<$S> {
             #[inline]
             fn into(self) -> $Tuple {
-                match self { $Self_ { $($field),+ } => ($($field),+) }
+                match self { $VectorN { $($field),+ } => ($($field),+) }
             }
         }
 
-        impl<$S> AsRef<$Tuple> for $Self_<$S> {
+        impl<$S> AsRef<$Tuple> for $VectorN<$S> {
             #[inline]
             fn as_ref(&self) -> &$Tuple {
                 unsafe { mem::transmute(self) }
             }
         }
 
-        impl<$S> AsMut<$Tuple> for $Self_<$S> {
+        impl<$S> AsMut<$Tuple> for $VectorN<$S> {
             #[inline]
             fn as_mut(&mut self) -> &mut $Tuple {
                 unsafe { mem::transmute(self) }
             }
         }
 
-        impl<$S> From<$Tuple> for $Self_<$S> {
+        impl<$S> From<$Tuple> for $VectorN<$S> {
             #[inline]
-            fn from(v: $Tuple) -> $Self_<$S> {
-                match v { ($($field),+) => $Self_ { $($field: $field),+ } }
+            fn from(v: $Tuple) -> $VectorN<$S> {
+                match v { ($($field),+) => $VectorN { $($field: $field),+ } }
             }
         }
 
-        impl<'a, $S> From<&'a $Tuple> for &'a $Self_<$S> {
+        impl<'a, $S> From<&'a $Tuple> for &'a $VectorN<$S> {
             #[inline]
-            fn from(v: &'a $Tuple) -> &'a $Self_<$S> {
+            fn from(v: &'a $Tuple) -> &'a $VectorN<$S> {
                 unsafe { mem::transmute(v) }
             }
         }
 
-        impl<'a, $S> From<&'a mut $Tuple> for &'a mut $Self_<$S> {
+        impl<'a, $S> From<&'a mut $Tuple> for &'a mut $VectorN<$S> {
             #[inline]
-            fn from(v: &'a mut $Tuple) -> &'a mut $Self_<$S> {
+            fn from(v: &'a mut $Tuple) -> &'a mut $VectorN<$S> {
                 unsafe { mem::transmute(v) }
             }
         }
@@ -683,5 +683,128 @@ impl<S: BaseNum> fmt::Debug for Vector3<S> {
 impl<S: BaseNum> fmt::Debug for Vector4<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[{:?}, {:?}, {:?}, {:?}]", self.x, self.y, self.z, self.w)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod vector2 {
+        use vector::*;
+
+        const VECTOR2: Vector2<i32> = Vector2 { x: 1, y: 2 };
+
+        #[test]
+        fn test_index() {
+            assert_eq!(VECTOR2[0], VECTOR2.x);
+            assert_eq!(VECTOR2[1], VECTOR2.y);
+        }
+
+        #[test]
+        fn test_index_mut() {
+            let mut v = VECTOR2;
+            *&mut v[0] = 0;
+            assert_eq!(v, [0, 2].into());
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_index_out_of_bounds() {
+            VECTOR2[2];
+        }
+
+        #[test]
+        fn test_index_range() {
+            assert_eq!(&VECTOR2[..0], &[]);
+            assert_eq!(&VECTOR2[..1], &[1]);
+            assert_eq!(VECTOR2[..0].len(), 0);
+            assert_eq!(VECTOR2[..1].len(), 1);
+            assert_eq!(&VECTOR2[2..], &[]);
+            assert_eq!(&VECTOR2[1..], &[2]);
+            assert_eq!(VECTOR2[2..].len(), 0);
+            assert_eq!(VECTOR2[1..].len(), 1);
+            assert_eq!(&VECTOR2[..], &[1, 2]);
+            assert_eq!(VECTOR2[..].len(), 2);
+        }
+    }
+
+    mod vector3 {
+        use vector::*;
+
+        const VECTOR3: Vector3<i32> = Vector3 { x: 1, y: 2, z: 3 };
+
+        #[test]
+        fn test_index() {
+            assert_eq!(VECTOR3[0], VECTOR3.x);
+            assert_eq!(VECTOR3[1], VECTOR3.y);
+            assert_eq!(VECTOR3[2], VECTOR3.z);
+        }
+
+        #[test]
+        fn test_index_mut() {
+            let mut v = VECTOR3;
+            *&mut v[1] = 0;
+            assert_eq!(v, [1, 0, 3].into());
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_index_out_of_bounds() {
+            VECTOR3[3];
+        }
+
+        #[test]
+        fn test_index_range() {
+            assert_eq!(&VECTOR3[..1], &[1]);
+            assert_eq!(&VECTOR3[..2], &[1, 2]);
+            assert_eq!(VECTOR3[..1].len(), 1);
+            assert_eq!(VECTOR3[..2].len(), 2);
+            assert_eq!(&VECTOR3[2..], &[3]);
+            assert_eq!(&VECTOR3[1..], &[2, 3]);
+            assert_eq!(VECTOR3[2..].len(), 1);
+            assert_eq!(VECTOR3[1..].len(), 2);
+            assert_eq!(&VECTOR3[..], &[1, 2, 3]);
+            assert_eq!(VECTOR3[..].len(), 3);
+        }
+    }
+
+    mod vector4 {
+        use vector::*;
+
+        const VECTOR4: Vector4<i32> = Vector4 { x: 1, y: 2, z: 3, w: 4 };
+
+        #[test]
+        fn test_index() {
+            assert_eq!(VECTOR4[0], VECTOR4.x);
+            assert_eq!(VECTOR4[1], VECTOR4.y);
+            assert_eq!(VECTOR4[2], VECTOR4.z);
+            assert_eq!(VECTOR4[3], VECTOR4.w);
+        }
+
+        #[test]
+        fn test_index_mut() {
+            let mut v = VECTOR4;
+            *&mut v[2] = 0;
+            assert_eq!(v, [1, 2, 0, 4].into());
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_index_out_of_bounds() {
+            VECTOR4[4];
+        }
+
+        #[test]
+        fn test_index_range() {
+            assert_eq!(&VECTOR4[..2], &[1, 2]);
+            assert_eq!(&VECTOR4[..3], &[1, 2, 3]);
+            assert_eq!(VECTOR4[..2].len(), 2);
+            assert_eq!(VECTOR4[..3].len(), 3);
+            assert_eq!(&VECTOR4[2..], &[3, 4]);
+            assert_eq!(&VECTOR4[1..], &[2, 3, 4]);
+            assert_eq!(VECTOR4[2..].len(), 2);
+            assert_eq!(VECTOR4[1..].len(), 3);
+            assert_eq!(&VECTOR4[..], &[1, 2, 3, 4]);
+            assert_eq!(VECTOR4[..].len(), 4);
+        }
     }
 }


### PR DESCRIPTION
Fixes #225
Closes #222

This is a breaking change and will probably require a version bump. I would like to do other things before this happens though, like removing all the operator methods in favor of implementing the operator traits.