### PR TITLE
Remove {Array1, Array2}::map method

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -41,10 +41,6 @@ pub trait Array1<Element: Copy>: Index<usize, Output=Element> + IndexMut<usize, 
     fn replace_elem(&mut self, i: usize, src: Element) -> Element {
         mem::replace(&mut (*self)[i], src)
     }
-
-    /// Apply a function to each element.
-    fn map<F>(&mut self, op: F) -> Self
-        where F:  FnMut(Element) -> Element;
 }
 
 /// A column-major array
@@ -85,8 +81,4 @@ pub trait Array2<Column: Array1<Element>+'static, Row: Array1<Element>, Element:
         let (bc, br) = b;
         unsafe { ptr::swap(&mut (*self)[ac][ar], &mut (*self)[bc][br]) };
     }
-
-    /// Apply a function to each column.
-    fn map<F>(&mut self, op: F) -> Self
-        where F: FnMut(&Column) -> Column;
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -569,13 +569,6 @@ impl<S: Copy + 'static> Array2<Vector2<S>, Vector2<S>, S> for Matrix2<S> {
         (&mut self[0]).swap_elems(a, b);
         (&mut self[1]).swap_elems(a, b);
     }
-
-    #[inline]
-    fn map<F>(&mut self, mut op: F) -> Matrix2<S> where F: FnMut(&Vector2<S>) -> Vector2<S> {
-        self.x = op(&self.x);
-        self.y = op(&self.y);
-        *self
-    }
 }
 
 impl<S: Copy + 'static> Array2<Vector3<S>, Vector3<S>, S> for Matrix3<S> {
@@ -591,14 +584,6 @@ impl<S: Copy + 'static> Array2<Vector3<S>, Vector3<S>, S> for Matrix3<S> {
         (&mut self[0]).swap_elems(a, b);
         (&mut self[1]).swap_elems(a, b);
         (&mut self[2]).swap_elems(a, b);
-    }
-
-    #[inline]
-    fn map<F>(&mut self, mut op: F) -> Matrix3<S> where F: FnMut(&Vector3<S>) -> Vector3<S> {
-        self.x = op(&self.x);
-        self.y = op(&self.y);
-        self.z = op(&self.z);
-        *self
     }
 }
 
@@ -617,15 +602,6 @@ impl<S: Copy + 'static> Array2<Vector4<S>, Vector4<S>, S> for Matrix4<S> {
         (&mut self[1]).swap_elems(a, b);
         (&mut self[2]).swap_elems(a, b);
         (&mut self[3]).swap_elems(a, b);
-    }
-
-    #[inline]
-    fn map<F>(&mut self, mut op: F) -> Matrix4<S> where F: FnMut(&Vector4<S>) -> Vector4<S> {
-        self.x = op(&self.x);
-        self.y = op(&self.y);
-        self.z = op(&self.z);
-        self.w = op(&self.w);
-        *self
     }
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -113,14 +113,7 @@ pub trait Point<S: BaseNum, V: Vector<S>>: Array1<S> + Clone {
     fn max(&self, p: &Self) -> Self;
 }
 
-impl<S: BaseNum> Array1<S> for Point2<S> {
-    #[inline]
-    fn map<F>(&mut self, mut op: F) -> Point2<S> where F: FnMut(S) -> S {
-        self.x = op(self.x);
-        self.y = op(self.y);
-        *self
-    }
-}
+impl<S: BaseNum> Array1<S> for Point2<S> {}
 
 impl<S: BaseNum> Point<S, Vector2<S>> for Point2<S> {
     #[inline]
@@ -220,15 +213,7 @@ impl<S: BaseFloat> ApproxEq<S> for Point2<S> {
     }
 }
 
-impl<S: BaseNum> Array1<S> for Point3<S> {
-    #[inline]
-    fn map<F>(&mut self, mut op: F) -> Point3<S> where F: FnMut(S) -> S {
-        self.x = op(self.x);
-        self.y = op(self.y);
-        self.z = op(self.z);
-        *self
-    }
-}
+impl<S: BaseNum> Array1<S> for Point3<S> {}
 
 impl<S: BaseNum> Point<S, Vector3<S>> for Point3<S> {
     #[inline]

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -40,16 +40,7 @@ pub struct Quaternion<S> {
     pub v: Vector3<S>,
 }
 
-impl<S: Copy + BaseFloat> Array1<S> for Quaternion<S> {
-    #[inline]
-    fn map<F>(&mut self, mut op: F) -> Quaternion<S> where F: FnMut(S) -> S {
-        self.s = op(self.s);
-        self.v.x = op(self.v.x);
-        self.v.y = op(self.v.y);
-        self.v.z = op(self.v.z);
-        *self
-    }
-}
+impl<S: Copy + BaseFloat> Array1<S> for Quaternion<S> {}
 
 impl<S: BaseFloat> Quaternion<S> {
     /// Construct a new quaternion from one scalar component and three

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -236,12 +236,7 @@ macro_rules! vec {
             }
         }
 
-        impl<$S: Copy> Array1<$S> for $Self_<$S> {
-            #[inline]
-            fn map<F>(&mut self, mut op: F) -> $Self_<$S> where F: FnMut($S) -> $S {
-                $(self.$field = op(self.$field);)+ *self
-            }
-        }
+        impl<$S: Copy> Array1<$S> for $Self_<$S> {}
 
         impl<S: BaseNum> Vector<S> for $Self_<S> {
             #[inline] fn from_value(s: S) -> $Self_<S> { $Self_ { $($field: s),+ } }

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -168,12 +168,6 @@ fn test_normalize() {
 }
 
 #[test]
-fn test_map() {
-    assert_eq!(Vector3::new(7.12f64, 3.8f64, -6.98f64).map(|x| x.floor()), Vector3::new(7.0f64, 3.0f64, -7.0f64));
-    assert_eq!(Vector3::new(7.12f64, 3.8f64, -6.98f64).map(|x| x.max(0.0f64)), Vector3::new(7.12f64, 3.8f64, 0.0f64));
-}
-
-#[test]
 fn test_cast() {
     assert_approx_eq!(Vector2::new(0.9f64, 1.5).cast(), Vector2::new(0.9f32, 1.5));
     assert_approx_eq!(Vector3::new(1.0f64, 2.4, -3.13).cast(), Vector3::new(1.0f32, 2.4, -3.13));


### PR DESCRIPTION
This doesn't seem to be used anywhere - not sure how useful it is. It isn't really a proper `map` anyway, because it mutates `self`.