### PR TITLE
Convert trait type parameters to associated types

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -80,7 +80,7 @@ pub trait Angle
 >
 :   Clone + Zero
 +   PartialEq + PartialOrd
-+   ApproxEq<S>
++   ApproxEq<Epsilon = S>
 +   Neg<Output=Self>
 +   Into<Rad<S>>
 +   Into<Deg<S>>
@@ -279,16 +279,18 @@ fmt::Debug for Deg<S> {
     }
 }
 
-impl<S: BaseFloat>
-ApproxEq<S> for Rad<S> {
+impl<S: BaseFloat> ApproxEq for Rad<S> {
+    type Epsilon = S;
+
     #[inline]
     fn approx_eq_eps(&self, other: &Rad<S>, epsilon: &S) -> bool {
         self.s.approx_eq_eps(&other.s, epsilon)
     }
 }
 
-impl<S: BaseFloat>
-ApproxEq<S> for Deg<S> {
+impl<S: BaseFloat> ApproxEq for Deg<S> {
+    type Epsilon = S;
+
     #[inline]
     fn approx_eq_eps(&self, other: &Deg<S>, epsilon: &S) -> bool {
         self.s.approx_eq_eps(&other.s, epsilon)

--- a/src/array.rs
+++ b/src/array.rs
@@ -19,6 +19,7 @@ use std::ops::*;
 
 /// An array containing elements of type `Element`
 pub trait Array1 where
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     Self: Index<usize, Output = <Self as Array1>::Element>,
     Self: IndexMut<usize, Output = <Self as Array1>::Element>,
 {
@@ -50,6 +51,7 @@ pub trait Array1 where
 
 /// A column-major array
 pub trait Array2 where
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     Self: Index<usize, Output = <Self as Array2>::Column>,
     Self: IndexMut<usize, Output = <Self as Array2>::Column>,
 {

--- a/src/array.rs
+++ b/src/array.rs
@@ -18,14 +18,19 @@ use std::ptr;
 use std::ops::*;
 
 /// An array containing elements of type `Element`
-pub trait Array1<Element: Copy>: Index<usize, Output=Element> + IndexMut<usize, Output=Element> {
+pub trait Array1 where
+    Self: Index<usize, Output = <Self as Array1>::Element>,
+    Self: IndexMut<usize, Output = <Self as Array1>::Element>,
+{
+    type Element: Copy;
+
     /// Get the pointer to the first element of the array.
-    fn ptr<'a>(&'a self) -> &'a Element {
+    fn ptr<'a>(&'a self) -> &'a Self::Element {
         &self[0]
     }
 
     /// Get a mutable pointer to the first element of the array.
-    fn mut_ptr<'a>(&'a mut self) -> &'a mut Element {
+    fn mut_ptr<'a>(&'a mut self) -> &'a mut Self::Element {
         &mut self[0]
     }
 
@@ -38,21 +43,27 @@ pub trait Array1<Element: Copy>: Index<usize, Output=Element> + IndexMut<usize, 
 
     /// Replace an element in the array.
     #[inline]
-    fn replace_elem(&mut self, i: usize, src: Element) -> Element {
+    fn replace_elem(&mut self, i: usize, src: Self::Element) -> Self::Element {
         mem::replace(&mut self[i], src)
     }
 }
 
 /// A column-major array
-pub trait Array2<Column: Array1<Element>+'static, Row: Array1<Element>, Element: Copy>:
-        Index<usize, Output=Column> + IndexMut<usize, Output=Column> {
+pub trait Array2 where
+    Self: Index<usize, Output = <Self as Array2>::Column>,
+    Self: IndexMut<usize, Output = <Self as Array2>::Column>,
+{
+    type Element: Copy;
+    type Column: Array1<Element = Self::Element>;
+    type Row: Array1<Element = Self::Element>;
+
     /// Get the pointer to the first element of the array.
-    fn ptr<'a>(&'a self) -> &'a Element {
+    fn ptr<'a>(&'a self) -> &'a Self::Element {
         &self[0][0]
     }
 
     /// Get a mutable pointer to the first element of the array.
-    fn mut_ptr<'a>(&'a mut self) -> &'a mut Element {
+    fn mut_ptr<'a>(&'a mut self) -> &'a mut Self::Element {
         &mut self[0][0]
     }
 
@@ -64,12 +75,12 @@ pub trait Array2<Column: Array1<Element>+'static, Row: Array1<Element>, Element:
 
     /// Replace a column in the array.
     #[inline]
-    fn replace_col(&mut self, c: usize, src: Column) -> Column {
+    fn replace_col(&mut self, c: usize, src: Self::Column) -> Self::Column {
         mem::replace(&mut self[c], src)
     }
 
     /// Get a row from this array by-value.
-    fn row(&self, r: usize) -> Row;
+    fn row(&self, r: usize) -> Self::Row;
 
     /// Swap two rows of this array.
     fn swap_rows(&mut self, a: usize, b: usize);

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -249,7 +249,9 @@ impl<S: Copy + Neg<Output = S>> Matrix4<S> {
     }
 }
 
-pub trait Matrix<S: BaseFloat, V: Vector<S> + 'static>: Array2<V, V, S> + ApproxEq<Epsilon = S> + Sized // where
+pub trait Matrix<S: BaseFloat, V: Vector<S>> where
+    Self: Array2<Element = S, Column = V, Row = V>,
+    Self: ApproxEq<Epsilon = S> + Sized,
     // FIXME: blocked by rust-lang/rust#20671
     //
     // for<'a, 'b> &'a Self: Add<&'b Self, Output = Self>,
@@ -359,7 +361,11 @@ pub trait Matrix<S: BaseFloat, V: Vector<S> + 'static>: Array2<V, V, S> + Approx
     fn is_symmetric(&self) -> bool;
 }
 
-impl<S: Copy + 'static> Array2<Vector2<S>, Vector2<S>, S> for Matrix2<S> {
+impl<S: Copy + 'static> Array2 for Matrix2<S> {
+    type Element = S;
+    type Column = Vector2<S>;
+    type Row = Vector2<S>;
+
     #[inline]
     fn row(&self, r: usize) -> Vector2<S> {
         Vector2::new(self[0][r],
@@ -373,7 +379,11 @@ impl<S: Copy + 'static> Array2<Vector2<S>, Vector2<S>, S> for Matrix2<S> {
     }
 }
 
-impl<S: Copy + 'static> Array2<Vector3<S>, Vector3<S>, S> for Matrix3<S> {
+impl<S: Copy + 'static> Array2 for Matrix3<S> {
+    type Element = S;
+    type Column = Vector3<S>;
+    type Row = Vector3<S>;
+
     #[inline]
     fn row(&self, r: usize) -> Vector3<S> {
         Vector3::new(self[0][r],
@@ -389,7 +399,11 @@ impl<S: Copy + 'static> Array2<Vector3<S>, Vector3<S>, S> for Matrix3<S> {
     }
 }
 
-impl<S: Copy + 'static> Array2<Vector4<S>, Vector4<S>, S> for Matrix4<S> {
+impl<S: Copy + 'static> Array2 for Matrix4<S> {
+    type Element = S;
+    type Column = Vector4<S>;
+    type Row = Vector4<S>;
+
     #[inline]
     fn row(&self, r: usize) -> Vector4<S> {
         Vector4::new(self[0][r],

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -250,6 +250,7 @@ impl<S: Copy + Neg<Output = S>> Matrix4<S> {
 }
 
 pub trait Matrix where
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     Self: Array2<
         Element = <<Self as Matrix>::ColumnRow as Vector>::Scalar,
         Column = <Self as Matrix>::ColumnRow,
@@ -268,6 +269,7 @@ pub trait Matrix where
     // for<'a> &'a Self: Div<S, Output = Self>,
     // for<'a> &'a Self: Rem<S, Output = Self>,
 {
+    // FIXME: Will not be needed once equality constraints in where clauses is implemented
     type ColumnRow: Vector;
 
     /// Create a new diagonal matrix using the supplied value.

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -249,7 +249,7 @@ impl<S: Copy + Neg<Output = S>> Matrix4<S> {
     }
 }
 
-pub trait Matrix<S: BaseFloat, V: Vector<S> + 'static>: Array2<V, V, S> + ApproxEq<S> + Sized // where
+pub trait Matrix<S: BaseFloat, V: Vector<S> + 'static>: Array2<V, V, S> + ApproxEq<Epsilon = S> + Sized // where
     // FIXME: blocked by rust-lang/rust#20671
     //
     // for<'a, 'b> &'a Self: Add<&'b Self, Output = Self>,
@@ -790,7 +790,9 @@ impl<S: BaseFloat> Matrix<S, Vector4<S>> for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> ApproxEq<S> for Matrix2<S> {
+impl<S: BaseFloat> ApproxEq for Matrix2<S> {
+    type Epsilon = S;
+
     #[inline]
     fn approx_eq_eps(&self, other: &Matrix2<S>, epsilon: &S) -> bool {
         self[0].approx_eq_eps(&other[0], epsilon) &&
@@ -798,7 +800,9 @@ impl<S: BaseFloat> ApproxEq<S> for Matrix2<S> {
     }
 }
 
-impl<S: BaseFloat> ApproxEq<S> for Matrix3<S> {
+impl<S: BaseFloat> ApproxEq for Matrix3<S> {
+    type Epsilon = S;
+
     #[inline]
     fn approx_eq_eps(&self, other: &Matrix3<S>, epsilon: &S) -> bool {
         self[0].approx_eq_eps(&other[0], epsilon) &&
@@ -807,7 +811,9 @@ impl<S: BaseFloat> ApproxEq<S> for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> ApproxEq<S> for Matrix4<S> {
+impl<S: BaseFloat> ApproxEq for Matrix4<S> {
+    type Epsilon = S;
+
     #[inline]
     fn approx_eq_eps(&self, other: &Matrix4<S>, epsilon: &S) -> bool {
         self[0].approx_eq_eps(&other[0], epsilon) &&

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -249,9 +249,14 @@ impl<S: Copy + Neg<Output = S>> Matrix4<S> {
     }
 }
 
-pub trait Matrix<S: BaseFloat, V: Vector<Scalar = S>> where
-    Self: Array2<Element = S, Column = V, Row = V>,
-    Self: ApproxEq<Epsilon = S> + Sized,
+pub trait Matrix where
+    Self: Array2<
+        Element = <<Self as Matrix>::ColumnRow as Vector>::Scalar,
+        Column = <Self as Matrix>::ColumnRow,
+        Row = <Self as Matrix>::ColumnRow,
+    >,
+    Self: ApproxEq<Epsilon = <<Self as Matrix>::ColumnRow as Vector>::Scalar> + Sized,
+    Self::Element: BaseFloat,
     // FIXME: blocked by rust-lang/rust#20671
     //
     // for<'a, 'b> &'a Self: Add<&'b Self, Output = Self>,
@@ -263,28 +268,30 @@ pub trait Matrix<S: BaseFloat, V: Vector<Scalar = S>> where
     // for<'a> &'a Self: Div<S, Output = Self>,
     // for<'a> &'a Self: Rem<S, Output = Self>,
 {
+    type ColumnRow: Vector;
+
     /// Create a new diagonal matrix using the supplied value.
-    fn from_value(value: S) -> Self;
+    fn from_value(value: Self::Element) -> Self;
     /// Create a matrix from a non-uniform scale
-    fn from_diagonal(value: &V) -> Self;
+    fn from_diagonal(diagonal: &Self::Column) -> Self;
 
     /// Create a matrix with all elements equal to zero.
     #[inline]
-    fn zero() -> Self { Self::from_value(S::zero()) }
+    fn zero() -> Self { Self::from_value(Self::Element::zero()) }
     /// Create a matrix where the each element of the diagonal is equal to one.
     #[inline]
-    fn one() -> Self { Self::from_value(S::one()) }
+    fn one() -> Self { Self::from_value(Self::Element::one()) }
 
     /// Multiply this matrix by a scalar, returning the new matrix.
     #[must_use]
-    fn mul_s(&self, s: S) -> Self;
+    fn mul_s(&self, s: Self::Element) -> Self;
     /// Divide this matrix by a scalar, returning the new matrix.
     #[must_use]
-    fn div_s(&self, s: S) -> Self;
+    fn div_s(&self, s: Self::Element) -> Self;
     /// Take the remainder of this matrix by a scalar, returning the new
     /// matrix.
     #[must_use]
-    fn rem_s(&self, s: S) -> Self;
+    fn rem_s(&self, s: Self::Element) -> Self;
 
     /// Add this matrix with another matrix, returning the new metrix.
     #[must_use]
@@ -294,18 +301,18 @@ pub trait Matrix<S: BaseFloat, V: Vector<Scalar = S>> where
     fn sub_m(&self, m: &Self) -> Self;
 
     /// Multiplay a vector by this matrix, returning a new vector.
-    fn mul_v(&self, v: &V) -> V;
+    fn mul_v(&self, v: &Self::Column) -> Self::Column;
 
     /// Multiply this matrix by another matrix, returning the new matrix.
     #[must_use]
     fn mul_m(&self, m: &Self) -> Self;
 
     /// Multiply this matrix by a scalar, in-place.
-    fn mul_self_s(&mut self, s: S);
+    fn mul_self_s(&mut self, s: Self::Element);
     /// Divide this matrix by a scalar, in-place.
-    fn div_self_s(&mut self, s: S);
+    fn div_self_s(&mut self, s: Self::Element);
     /// Take the remainder of this matrix, in-place.
-    fn rem_self_s(&mut self, s: S);
+    fn rem_self_s(&mut self, s: Self::Element);
 
     /// Add this matrix with another matrix, in-place.
     fn add_self_m(&mut self, m: &Self);
@@ -322,14 +329,14 @@ pub trait Matrix<S: BaseFloat, V: Vector<Scalar = S>> where
     /// Transpose this matrix in-place.
     fn transpose_self(&mut self);
     /// Take the determinant of this matrix.
-    fn determinant(&self) -> S;
+    fn determinant(&self) -> Self::Element;
 
     /// Return a vector containing the diagonal of this matrix.
-    fn diagonal(&self) -> V;
+    fn diagonal(&self) -> Self::Column;
 
     /// Return the trace of this matrix. That is, the sum of the diagonal.
     #[inline]
-    fn trace(&self) -> S { self.diagonal().sum() }
+    fn trace(&self) -> Self::Element { self.diagonal().sum() }
 
     /// Invert this matrix, returning a new matrix. `m.mul_m(m.invert())` is
     /// the identity matrix. Returns `None` if this matrix is not invertible
@@ -345,7 +352,7 @@ pub trait Matrix<S: BaseFloat, V: Vector<Scalar = S>> where
 
     /// Test if this matrix is invertible.
     #[inline]
-    fn is_invertible(&self) -> bool { !self.determinant().approx_eq(&S::zero()) }
+    fn is_invertible(&self) -> bool { !self.determinant().approx_eq(&Self::Element::zero()) }
 
     /// Test if this matrix is the identity matrix. That is, it is diagonal
     /// and every element in the diagonal is one.
@@ -361,7 +368,7 @@ pub trait Matrix<S: BaseFloat, V: Vector<Scalar = S>> where
     fn is_symmetric(&self) -> bool;
 }
 
-impl<S: Copy + 'static> Array2 for Matrix2<S> {
+impl<S: Copy> Array2 for Matrix2<S> {
     type Element = S;
     type Column = Vector2<S>;
     type Row = Vector2<S>;
@@ -379,7 +386,7 @@ impl<S: Copy + 'static> Array2 for Matrix2<S> {
     }
 }
 
-impl<S: Copy + 'static> Array2 for Matrix3<S> {
+impl<S: Copy> Array2 for Matrix3<S> {
     type Element = S;
     type Column = Vector3<S>;
     type Row = Vector3<S>;
@@ -399,7 +406,7 @@ impl<S: Copy + 'static> Array2 for Matrix3<S> {
     }
 }
 
-impl<S: Copy + 'static> Array2 for Matrix4<S> {
+impl<S: Copy> Array2 for Matrix4<S> {
     type Element = S;
     type Column = Vector4<S>;
     type Row = Vector4<S>;
@@ -421,7 +428,9 @@ impl<S: Copy + 'static> Array2 for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> Matrix<S, Vector2<S>> for Matrix2<S> {
+impl<S: BaseFloat> Matrix for Matrix2<S> {
+    type ColumnRow = Vector2<S>;
+
     #[inline]
     fn from_value(value: S) -> Matrix2<S> {
         Matrix2::new(value, S::zero(),
@@ -518,7 +527,9 @@ impl<S: BaseFloat> Matrix<S, Vector2<S>> for Matrix2<S> {
     }
 }
 
-impl<S: BaseFloat> Matrix<S, Vector3<S>> for Matrix3<S> {
+impl<S: BaseFloat> Matrix for Matrix3<S> {
+    type ColumnRow = Vector3<S>;
+
     #[inline]
     fn from_value(value: S) -> Matrix3<S> {
         Matrix3::new(value, S::zero(), S::zero(),
@@ -634,7 +645,9 @@ impl<S: BaseFloat> Matrix<S, Vector3<S>> for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> Matrix<S, Vector4<S>> for Matrix4<S> {
+impl<S: BaseFloat> Matrix for Matrix4<S> {
+    type ColumnRow = Vector4<S>;
+
     #[inline]
     fn from_value(value: S) -> Matrix4<S> {
         Matrix4::new(value, S::zero(), S::zero(), S::zero(),

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -249,7 +249,7 @@ impl<S: Copy + Neg<Output = S>> Matrix4<S> {
     }
 }
 
-pub trait Matrix<S: BaseFloat, V: Vector<S>> where
+pub trait Matrix<S: BaseFloat, V: Vector<Scalar = S>> where
     Self: Array2<Element = S, Column = V, Row = V>,
     Self: ApproxEq<Epsilon = S> + Sized,
     // FIXME: blocked by rust-lang/rust#20671

--- a/src/num.rs
+++ b/src/num.rs
@@ -110,7 +110,7 @@ impl BaseInt for u64 {}
 impl BaseInt for usize {}
 
 /// Base floating point types
-pub trait BaseFloat : BaseNum + Float + ApproxEq<Self> {}
+pub trait BaseFloat : BaseNum + Float + ApproxEq<Epsilon = Self> {}
 
 impl BaseFloat for f32 {}
 impl BaseFloat for f64 {}

--- a/src/point.rs
+++ b/src/point.rs
@@ -190,7 +190,9 @@ impl<S: BaseNum> Point<S> for Point2<S> {
     }
 }
 
-impl<S: BaseFloat> ApproxEq<S> for Point2<S> {
+impl<S: BaseFloat> ApproxEq for Point2<S> {
+    type Epsilon = S;
+
     #[inline]
     fn approx_eq_eps(&self, other: &Point2<S>, epsilon: &S) -> bool {
         self.x.approx_eq_eps(&other.x, epsilon) &&
@@ -270,7 +272,9 @@ impl<S: BaseNum> Point<S> for Point3<S> {
     }
 }
 
-impl<S: BaseFloat> ApproxEq<S> for Point3<S> {
+impl<S: BaseFloat> ApproxEq for Point3<S> {
+    type Epsilon = S;
+
     #[inline]
     fn approx_eq_eps(&self, other: &Point3<S>, epsilon: &S) -> bool {
         self.x.approx_eq_eps(&other.x, epsilon) &&

--- a/src/point.rs
+++ b/src/point.rs
@@ -66,7 +66,7 @@ impl<S: BaseNum> Point3<S> {
 }
 
 /// Specifies the numeric operations for point types.
-pub trait Point<S: BaseNum, V: Vector<S>>: Array1<S> + Clone // where
+pub trait Point<S: BaseNum>: Array1<S> + Clone // where
     // FIXME: blocked by rust-lang/rust#20671
     //
     // for<'a, 'b> &'a Self: Add<&'b V, Output = Self>,
@@ -76,13 +76,16 @@ pub trait Point<S: BaseNum, V: Vector<S>>: Array1<S> + Clone // where
     // for<'a> &'a Self: Div<S, Output = Self>,
     // for<'a> &'a Self: Rem<S, Output = Self>,
 {
+    /// The associated displacement vector.
+    type Vector: Vector<S>;
+
     /// Create a point at the origin.
     fn origin() -> Self;
 
     /// Create a point from a vector.
-    fn from_vec(v: &V) -> Self;
+    fn from_vec(v: &Self::Vector) -> Self;
     /// Convert a point to a vector.
-    fn to_vec(&self) -> V;
+    fn to_vec(&self) -> Self::Vector;
 
     /// Multiply each component by a scalar, returning the new point.
     #[must_use]
@@ -96,9 +99,9 @@ pub trait Point<S: BaseNum, V: Vector<S>>: Array1<S> + Clone // where
 
     /// Add a vector to this point, returning the new point.
     #[must_use]
-    fn add_v(&self, v: &V) -> Self;
+    fn add_v(&self, v: &Self::Vector) -> Self;
     /// Subtract another point from this one, returning a new vector.
-    fn sub_p(&self, p: &Self) -> V;
+    fn sub_p(&self, p: &Self) -> Self::Vector;
 
     /// Multiply each component by a scalar, in-place.
     fn mul_self_s(&mut self, s: S);
@@ -108,10 +111,10 @@ pub trait Point<S: BaseNum, V: Vector<S>>: Array1<S> + Clone // where
     fn rem_self_s(&mut self, s: S);
 
     /// Add a vector to this point, in-place.
-    fn add_self_v(&mut self, v: &V);
+    fn add_self_v(&mut self, v: &Self::Vector);
 
     /// This is a weird one, but its useful for plane calculations.
-    fn dot(&self, v: &V) -> S;
+    fn dot(&self, v: &Self::Vector) -> S;
 
     #[must_use]
     fn min(&self, p: &Self) -> Self;
@@ -122,7 +125,9 @@ pub trait Point<S: BaseNum, V: Vector<S>>: Array1<S> + Clone // where
 
 impl<S: BaseNum> Array1<S> for Point2<S> {}
 
-impl<S: BaseNum> Point<S, Vector2<S>> for Point2<S> {
+impl<S: BaseNum> Point<S> for Point2<S> {
+    type Vector = Vector2<S>;
+
     #[inline]
     fn origin() -> Point2<S> {
         Point2::new(S::zero(), S::zero())
@@ -195,7 +200,9 @@ impl<S: BaseFloat> ApproxEq<S> for Point2<S> {
 
 impl<S: BaseNum> Array1<S> for Point3<S> {}
 
-impl<S: BaseNum> Point<S, Vector3<S>> for Point3<S> {
+impl<S: BaseNum> Point<S> for Point3<S> {
+    type Vector = Vector3<S>;
+
     #[inline]
     fn origin() -> Point3<S> {
         Point3::new(S::zero(), S::zero(), S::zero())

--- a/src/point.rs
+++ b/src/point.rs
@@ -66,7 +66,7 @@ impl<S: BaseNum> Point3<S> {
 }
 
 /// Specifies the numeric operations for point types.
-pub trait Point<S: BaseNum>: Array1<S> + Clone // where
+pub trait Point<S: BaseNum>: Array1<Element = S> + Clone // where
     // FIXME: blocked by rust-lang/rust#20671
     //
     // for<'a, 'b> &'a Self: Add<&'b V, Output = Self>,
@@ -123,7 +123,9 @@ pub trait Point<S: BaseNum>: Array1<S> + Clone // where
     fn max(&self, p: &Self) -> Self;
 }
 
-impl<S: BaseNum> Array1<S> for Point2<S> {}
+impl<S: BaseNum> Array1 for Point2<S> {
+    type Element = S;
+}
 
 impl<S: BaseNum> Point<S> for Point2<S> {
     type Vector = Vector2<S>;
@@ -200,7 +202,9 @@ impl<S: BaseFloat> ApproxEq for Point2<S> {
     }
 }
 
-impl<S: BaseNum> Array1<S> for Point3<S> {}
+impl<S: BaseNum> Array1 for Point3<S> {
+    type Element = S;
+}
 
 impl<S: BaseNum> Point<S> for Point3<S> {
     type Vector = Vector3<S>;

--- a/src/point.rs
+++ b/src/point.rs
@@ -66,7 +66,7 @@ impl<S: BaseNum> Point3<S> {
 }
 
 /// Specifies the numeric operations for point types.
-pub trait Point<S: BaseNum>: Array1<Element = S> + Clone // where
+pub trait Point: Array1<Element = <<Self as Point>::Vector as Vector>::Scalar> + Clone // where
     // FIXME: blocked by rust-lang/rust#20671
     //
     // for<'a, 'b> &'a Self: Add<&'b V, Output = Self>,
@@ -77,7 +77,7 @@ pub trait Point<S: BaseNum>: Array1<Element = S> + Clone // where
     // for<'a> &'a Self: Rem<S, Output = Self>,
 {
     /// The associated displacement vector.
-    type Vector: Vector<Scalar = S>;
+    type Vector: Vector;
 
     /// Create a point at the origin.
     fn origin() -> Self;
@@ -89,13 +89,13 @@ pub trait Point<S: BaseNum>: Array1<Element = S> + Clone // where
 
     /// Multiply each component by a scalar, returning the new point.
     #[must_use]
-    fn mul_s(&self, s: S) -> Self;
+    fn mul_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Self;
     /// Divide each component by a scalar, returning the new point.
     #[must_use]
-    fn div_s(&self, s: S) -> Self;
+    fn div_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Self;
     /// Subtract a scalar from each component, returning the new point.
     #[must_use]
-    fn rem_s(&self, s: S) -> Self;
+    fn rem_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Self;
 
     /// Add a vector to this point, returning the new point.
     #[must_use]
@@ -104,17 +104,17 @@ pub trait Point<S: BaseNum>: Array1<Element = S> + Clone // where
     fn sub_p(&self, p: &Self) -> Self::Vector;
 
     /// Multiply each component by a scalar, in-place.
-    fn mul_self_s(&mut self, s: S);
+    fn mul_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar);
     /// Divide each component by a scalar, in-place.
-    fn div_self_s(&mut self, s: S);
+    fn div_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar);
     /// Take the remainder of each component by a scalar, in-place.
-    fn rem_self_s(&mut self, s: S);
+    fn rem_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar);
 
     /// Add a vector to this point, in-place.
     fn add_self_v(&mut self, v: &Self::Vector);
 
     /// This is a weird one, but its useful for plane calculations.
-    fn dot(&self, v: &Self::Vector) -> S;
+    fn dot(&self, v: &Self::Vector) -> <<Self as Point>::Vector as Vector>::Scalar;
 
     #[must_use]
     fn min(&self, p: &Self) -> Self;
@@ -127,7 +127,7 @@ impl<S: BaseNum> Array1 for Point2<S> {
     type Element = S;
 }
 
-impl<S: BaseNum> Point<S> for Point2<S> {
+impl<S: BaseNum> Point for Point2<S> {
     type Vector = Vector2<S>;
 
     #[inline]
@@ -145,28 +145,28 @@ impl<S: BaseNum> Point<S> for Point2<S> {
         Vector2::new(self.x, self.y)
     }
 
-    #[inline] fn mul_s(&self, s: S) -> Point2<S> { self * s }
-    #[inline] fn div_s(&self, s: S) -> Point2<S> { self / s }
-    #[inline] fn rem_s(&self, s: S) -> Point2<S> { self % s }
+    #[inline] fn mul_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point2<S> { self * scalar }
+    #[inline] fn div_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point2<S> { self / scalar }
+    #[inline] fn rem_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point2<S> { self % scalar }
     #[inline] fn add_v(&self, v: &Vector2<S>) -> Point2<S> { self + v }
     #[inline] fn sub_p(&self, p: &Point2<S>) -> Vector2<S> { self - p }
 
     #[inline]
-    fn mul_self_s(&mut self, s: S) {
-        self.x = self.x * s;
-        self.y = self.y * s;
+    fn mul_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+        self.x = self.x * scalar;
+        self.y = self.y * scalar;
     }
 
     #[inline]
-    fn div_self_s(&mut self, s: S) {
-        self.x = self.x / s;
-        self.y = self.y / s;
+    fn div_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+        self.x = self.x / scalar;
+        self.y = self.y / scalar;
     }
 
     #[inline]
-    fn rem_self_s(&mut self, s: S) {
-        self.x = self.x % s;
-        self.y = self.y % s;
+    fn rem_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+        self.x = self.x % scalar;
+        self.y = self.y % scalar;
     }
 
     #[inline]
@@ -206,7 +206,7 @@ impl<S: BaseNum> Array1 for Point3<S> {
     type Element = S;
 }
 
-impl<S: BaseNum> Point<S> for Point3<S> {
+impl<S: BaseNum> Point for Point3<S> {
     type Vector = Vector3<S>;
 
     #[inline]
@@ -224,31 +224,31 @@ impl<S: BaseNum> Point<S> for Point3<S> {
         Vector3::new(self.x, self.y, self.z)
     }
 
-    #[inline] fn mul_s(&self, s: S) -> Point3<S> { self * s }
-    #[inline] fn div_s(&self, s: S) -> Point3<S> { self / s }
-    #[inline] fn rem_s(&self, s: S) -> Point3<S> { self % s }
+    #[inline] fn mul_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point3<S> { self * scalar }
+    #[inline] fn div_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point3<S> { self / scalar }
+    #[inline] fn rem_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point3<S> { self % scalar }
     #[inline] fn add_v(&self, v: &Vector3<S>) -> Point3<S> { self + v }
     #[inline] fn sub_p(&self, p: &Point3<S>) -> Vector3<S> { self - p }
 
     #[inline]
-    fn mul_self_s(&mut self, s: S) {
-        self.x = self.x * s;
-        self.y = self.y * s;
-        self.z = self.z * s;
+    fn mul_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+        self.x = self.x * scalar;
+        self.y = self.y * scalar;
+        self.z = self.z * scalar;
     }
 
     #[inline]
-    fn div_self_s(&mut self, s: S) {
-        self.x = self.x / s;
-        self.y = self.y / s;
-        self.z = self.z / s;
+    fn div_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+        self.x = self.x / scalar;
+        self.y = self.y / scalar;
+        self.z = self.z / scalar;
     }
 
     #[inline]
-    fn rem_self_s(&mut self, s: S) {
-        self.x = self.x % s;
-        self.y = self.y % s;
-        self.z = self.z % s;
+    fn rem_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+        self.x = self.x % scalar;
+        self.y = self.y % scalar;
+        self.z = self.z % scalar;
     }
 
     #[inline]
@@ -294,8 +294,8 @@ macro_rules! impl_operators {
             type Output = $PointN<S>;
 
             #[inline]
-            fn mul(self, s: S) -> $PointN<S> {
-                $PointN::new($(self.$field * s),+)
+            fn mul(self, scalar: S) -> $PointN<S> {
+                $PointN::new($(self.$field * scalar),+)
             }
         }
 
@@ -303,8 +303,8 @@ macro_rules! impl_operators {
             type Output = $PointN<S>;
 
             #[inline]
-            fn div(self, s: S) -> $PointN<S> {
-                $PointN::new($(self.$field / s),+)
+            fn div(self, scalar: S) -> $PointN<S> {
+                $PointN::new($(self.$field / scalar),+)
             }
         }
 
@@ -312,8 +312,8 @@ macro_rules! impl_operators {
             type Output = $PointN<S>;
 
             #[inline]
-            fn rem(self, s: S) -> $PointN<S> {
-                $PointN::new($(self.$field % s),+)
+            fn rem(self, scalar: S) -> $PointN<S> {
+                $PointN::new($(self.$field % scalar),+)
             }
         }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -77,7 +77,7 @@ pub trait Point<S: BaseNum>: Array1<Element = S> + Clone // where
     // for<'a> &'a Self: Rem<S, Output = Self>,
 {
     /// The associated displacement vector.
-    type Vector: Vector<S>;
+    type Vector: Vector<Scalar = S>;
 
     /// Create a point at the origin.
     fn origin() -> Self;

--- a/src/point.rs
+++ b/src/point.rs
@@ -68,7 +68,7 @@ impl<S: BaseNum> Point3<S> {
 /// Specifies the numeric operations for point types.
 pub trait Point: Clone where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
-    Self: Array1<Element = <<Self as Point>::Vector as Vector>::Scalar>,
+    Self: Array1<Element = <Self as Point>::Scalar>,
     // FIXME: blocked by rust-lang/rust#20671
     //
     // for<'a, 'b> &'a Self: Add<&'b V, Output = Self>,
@@ -78,8 +78,13 @@ pub trait Point: Clone where
     // for<'a> &'a Self: Div<S, Output = Self>,
     // for<'a> &'a Self: Rem<S, Output = Self>,
 {
+    /// The associated scalar.
+    ///
+    /// Due to the equality constraints demanded by `Self::Vector`, this is effectively just an
+    /// alias to `Self::Vector::Scalar`.
+    type Scalar: BaseNum;
     /// The associated displacement vector.
-    type Vector: Vector;
+    type Vector: Vector<Scalar = Self::Scalar>;
 
     /// Create a point at the origin.
     fn origin() -> Self;
@@ -91,13 +96,13 @@ pub trait Point: Clone where
 
     /// Multiply each component by a scalar, returning the new point.
     #[must_use]
-    fn mul_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Self;
+    fn mul_s(&self, scalar: Self::Scalar) -> Self;
     /// Divide each component by a scalar, returning the new point.
     #[must_use]
-    fn div_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Self;
+    fn div_s(&self, scalar: Self::Scalar) -> Self;
     /// Subtract a scalar from each component, returning the new point.
     #[must_use]
-    fn rem_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Self;
+    fn rem_s(&self, scalar: Self::Scalar) -> Self;
 
     /// Add a vector to this point, returning the new point.
     #[must_use]
@@ -106,17 +111,17 @@ pub trait Point: Clone where
     fn sub_p(&self, p: &Self) -> Self::Vector;
 
     /// Multiply each component by a scalar, in-place.
-    fn mul_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar);
+    fn mul_self_s(&mut self, scalar: Self::Scalar);
     /// Divide each component by a scalar, in-place.
-    fn div_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar);
+    fn div_self_s(&mut self, scalar: Self::Scalar);
     /// Take the remainder of each component by a scalar, in-place.
-    fn rem_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar);
+    fn rem_self_s(&mut self, scalar: Self::Scalar);
 
     /// Add a vector to this point, in-place.
     fn add_self_v(&mut self, v: &Self::Vector);
 
     /// This is a weird one, but its useful for plane calculations.
-    fn dot(&self, v: &Self::Vector) -> <<Self as Point>::Vector as Vector>::Scalar;
+    fn dot(&self, v: &Self::Vector) -> Self::Scalar;
 
     #[must_use]
     fn min(&self, p: &Self) -> Self;
@@ -130,6 +135,7 @@ impl<S: BaseNum> Array1 for Point2<S> {
 }
 
 impl<S: BaseNum> Point for Point2<S> {
+    type Scalar = S;
     type Vector = Vector2<S>;
 
     #[inline]
@@ -147,26 +153,26 @@ impl<S: BaseNum> Point for Point2<S> {
         Vector2::new(self.x, self.y)
     }
 
-    #[inline] fn mul_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point2<S> { self * scalar }
-    #[inline] fn div_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point2<S> { self / scalar }
-    #[inline] fn rem_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point2<S> { self % scalar }
+    #[inline] fn mul_s(&self, scalar: S) -> Point2<S> { self * scalar }
+    #[inline] fn div_s(&self, scalar: S) -> Point2<S> { self / scalar }
+    #[inline] fn rem_s(&self, scalar: S) -> Point2<S> { self % scalar }
     #[inline] fn add_v(&self, v: &Vector2<S>) -> Point2<S> { self + v }
     #[inline] fn sub_p(&self, p: &Point2<S>) -> Vector2<S> { self - p }
 
     #[inline]
-    fn mul_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+    fn mul_self_s(&mut self, scalar: S) {
         self.x = self.x * scalar;
         self.y = self.y * scalar;
     }
 
     #[inline]
-    fn div_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+    fn div_self_s(&mut self, scalar: S) {
         self.x = self.x / scalar;
         self.y = self.y / scalar;
     }
 
     #[inline]
-    fn rem_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+    fn rem_self_s(&mut self, scalar: S) {
         self.x = self.x % scalar;
         self.y = self.y % scalar;
     }
@@ -209,6 +215,7 @@ impl<S: BaseNum> Array1 for Point3<S> {
 }
 
 impl<S: BaseNum> Point for Point3<S> {
+    type Scalar = S;
     type Vector = Vector3<S>;
 
     #[inline]
@@ -226,28 +233,28 @@ impl<S: BaseNum> Point for Point3<S> {
         Vector3::new(self.x, self.y, self.z)
     }
 
-    #[inline] fn mul_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point3<S> { self * scalar }
-    #[inline] fn div_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point3<S> { self / scalar }
-    #[inline] fn rem_s(&self, scalar: <<Self as Point>::Vector as Vector>::Scalar) -> Point3<S> { self % scalar }
+    #[inline] fn mul_s(&self, scalar: S) -> Point3<S> { self * scalar }
+    #[inline] fn div_s(&self, scalar: S) -> Point3<S> { self / scalar }
+    #[inline] fn rem_s(&self, scalar: S) -> Point3<S> { self % scalar }
     #[inline] fn add_v(&self, v: &Vector3<S>) -> Point3<S> { self + v }
     #[inline] fn sub_p(&self, p: &Point3<S>) -> Vector3<S> { self - p }
 
     #[inline]
-    fn mul_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+    fn mul_self_s(&mut self, scalar: S) {
         self.x = self.x * scalar;
         self.y = self.y * scalar;
         self.z = self.z * scalar;
     }
 
     #[inline]
-    fn div_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+    fn div_self_s(&mut self, scalar: S) {
         self.x = self.x / scalar;
         self.y = self.y / scalar;
         self.z = self.z / scalar;
     }
 
     #[inline]
-    fn rem_self_s(&mut self, scalar: <<Self as Point>::Vector as Vector>::Scalar) {
+    fn rem_self_s(&mut self, scalar: S) {
         self.x = self.x % scalar;
         self.y = self.y % scalar;
         self.z = self.z % scalar;

--- a/src/point.rs
+++ b/src/point.rs
@@ -66,7 +66,9 @@ impl<S: BaseNum> Point3<S> {
 }
 
 /// Specifies the numeric operations for point types.
-pub trait Point: Array1<Element = <<Self as Point>::Vector as Vector>::Scalar> + Clone // where
+pub trait Point: Clone where
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
+    Self: Array1<Element = <<Self as Point>::Vector as Vector>::Scalar>,
     // FIXME: blocked by rust-lang/rust#20671
     //
     // for<'a, 'b> &'a Self: Add<&'b V, Output = Self>,

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -40,7 +40,9 @@ pub struct Quaternion<S> {
     pub v: Vector3<S>,
 }
 
-impl<S: Copy + BaseFloat> Array1<S> for Quaternion<S> {}
+impl<S: Copy + BaseFloat> Array1 for Quaternion<S> {
+    type Element = S;
+}
 
 impl<S: BaseFloat> Quaternion<S> {
     /// Construct a new quaternion from one scalar component and three

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -339,7 +339,7 @@ impl<S: BaseFloat> From<Quaternion<S>> for Basis3<S> {
     fn from(quat: Quaternion<S>) -> Basis3<S> { Basis3::from_quaternion(&quat) }
 }
 
-impl<S: BaseFloat + 'static> Rotation<S, Vector3<S>, Point3<S>> for Quaternion<S> {
+impl<S: BaseFloat + 'static> Rotation<S, Point3<S>> for Quaternion<S> {
     #[inline]
     fn one() -> Quaternion<S> { Quaternion::one() }
 

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -170,7 +170,9 @@ impl<'a, 'b, S: BaseFloat> Mul<&'b Quaternion<S>> for &'a Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> ApproxEq<S> for Quaternion<S> {
+impl<S: BaseFloat> ApproxEq for Quaternion<S> {
+    type Epsilon = S;
+
     #[inline]
     fn approx_eq_eps(&self, other: &Quaternion<S>, epsilon: &S) -> bool {
         self.s.approx_eq_eps(&other.s, epsilon) &&

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -343,7 +343,7 @@ impl<S: BaseFloat> From<Quaternion<S>> for Basis3<S> {
     fn from(quat: Quaternion<S>) -> Basis3<S> { Basis3::from_quaternion(&quat) }
 }
 
-impl<S: BaseFloat + 'static> Rotation<S, Point3<S>> for Quaternion<S> {
+impl<S: BaseFloat> Rotation<Point3<S>> for Quaternion<S> {
     #[inline]
     fn one() -> Quaternion<S> { Quaternion::one() }
 

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -25,19 +25,19 @@ use vector::{Vector, Vector2, Vector3};
 
 /// A trait for a generic rotation. A rotation is a transformation that
 /// creates a circular motion, and preserves at least one point in the space.
-pub trait Rotation<S: BaseFloat, V: Vector<S>, P: Point<S, V>>: PartialEq + ApproxEq<S> + Sized {
+pub trait Rotation<S: BaseFloat, P: Point<S>>: PartialEq + ApproxEq<S> + Sized {
     /// Create the identity transform (causes no transformation).
     fn one() -> Self;
 
     /// Create a rotation to a given direction with an 'up' vector
-    fn look_at(dir: &V, up: &V) -> Self;
+    fn look_at(dir: &P::Vector, up: &P::Vector) -> Self;
 
     /// Create a shortest rotation to transform vector 'a' into 'b'.
     /// Both given vectors are assumed to have unit length.
-    fn between_vectors(a: &V, b: &V) -> Self;
+    fn between_vectors(a: &P::Vector, b: &P::Vector) -> Self;
 
     /// Rotate a vector using this rotation.
-    fn rotate_vector(&self, vec: &V) -> V;
+    fn rotate_vector(&self, vec: &P::Vector) -> P::Vector;
 
     /// Rotate a point using this rotation, by converting it to its
     /// representation as a vector.
@@ -67,7 +67,7 @@ pub trait Rotation<S: BaseFloat, V: Vector<S>, P: Point<S, V>>: PartialEq + Appr
 }
 
 /// A two-dimensional rotation.
-pub trait Rotation2<S: BaseFloat>: Rotation<S, Vector2<S>, Point2<S>>
+pub trait Rotation2<S: BaseFloat>: Rotation<S, Point2<S>>
                                  + Into<Matrix2<S>>
                                  + Into<Basis2<S>> {
     /// Create a rotation by a given angle. Thus is a redundant case of both
@@ -76,7 +76,7 @@ pub trait Rotation2<S: BaseFloat>: Rotation<S, Vector2<S>, Point2<S>>
 }
 
 /// A three-dimensional rotation.
-pub trait Rotation3<S: BaseFloat>: Rotation<S, Vector3<S>, Point3<S>>
+pub trait Rotation3<S: BaseFloat>: Rotation<S, Point3<S>>
                                  + Into<Matrix3<S>>
                                  + Into<Basis3<S>>
                                  + Into<Quaternion<S>> {
@@ -172,7 +172,7 @@ impl<S: BaseFloat> From<Basis2<S>> for Matrix2<S> {
     fn from(b: Basis2<S>) -> Matrix2<S> { b.mat }
 }
 
-impl<S: BaseFloat + 'static> Rotation<S, Vector2<S>, Point2<S>> for Basis2<S> {
+impl<S: BaseFloat> Rotation<S, Point2<S>> for Basis2<S> {
     #[inline]
     fn one() -> Basis2<S> { Basis2 { mat: Matrix2::one() } }
 
@@ -213,7 +213,7 @@ impl<S: BaseFloat> ApproxEq<S> for Basis2<S> {
     }
 }
 
-impl<S: BaseFloat + 'static> Rotation2<S> for Basis2<S> {
+impl<S: BaseFloat> Rotation2<S> for Basis2<S> {
     fn from_angle(theta: Rad<S>) -> Basis2<S> { Basis2 { mat: Matrix2::from_angle(theta) } }
 }
 
@@ -248,12 +248,12 @@ impl<S: BaseFloat> From<Basis3<S>> for Matrix3<S> {
     fn from(b: Basis3<S>) -> Matrix3<S> { b.mat }
 }
 
-impl<S: BaseFloat + 'static> From<Basis3<S>> for Quaternion<S> {
+impl<S: BaseFloat> From<Basis3<S>> for Quaternion<S> {
     #[inline]
     fn from(b: Basis3<S>) -> Quaternion<S> { b.mat.into() }
 }
 
-impl<S: BaseFloat + 'static> Rotation<S, Vector3<S>, Point3<S>> for Basis3<S> {
+impl<S: BaseFloat> Rotation<S, Point3<S>> for Basis3<S> {
     #[inline]
     fn one() -> Basis3<S> { Basis3 { mat: Matrix3::one() } }
 
@@ -295,7 +295,7 @@ impl<S: BaseFloat> ApproxEq<S> for Basis3<S> {
     }
 }
 
-impl<S: BaseFloat + 'static> Rotation3<S> for Basis3<S> {
+impl<S: BaseFloat> Rotation3<S> for Basis3<S> {
     fn from_axis_angle(axis: &Vector3<S>, angle: Rad<S>) -> Basis3<S> {
         Basis3 { mat: Matrix3::from_axis_angle(axis, angle) }
     }

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -25,7 +25,7 @@ use vector::{Vector, Vector2, Vector3};
 
 /// A trait for a generic rotation. A rotation is a transformation that
 /// creates a circular motion, and preserves at least one point in the space.
-pub trait Rotation<S: BaseFloat, P: Point<S>>: PartialEq + ApproxEq<S> + Sized {
+pub trait Rotation<S: BaseFloat, P: Point<S>>: PartialEq + ApproxEq<Epsilon = S> + Sized {
     /// Create the identity transform (causes no transformation).
     fn one() -> Self;
 
@@ -206,7 +206,9 @@ impl<S: BaseFloat> Rotation<S, Point2<S>> for Basis2<S> {
     fn invert_self(&mut self) { self.mat.invert_self(); }
 }
 
-impl<S: BaseFloat> ApproxEq<S> for Basis2<S> {
+impl<S: BaseFloat> ApproxEq for Basis2<S> {
+    type Epsilon = S;
+
     #[inline]
     fn approx_eq_eps(&self, other: &Basis2<S>, epsilon: &S) -> bool {
         self.mat.approx_eq_eps(&other.mat, epsilon)
@@ -288,7 +290,9 @@ impl<S: BaseFloat> Rotation<S, Point3<S>> for Basis3<S> {
     fn invert_self(&mut self) { self.mat.invert_self(); }
 }
 
-impl<S: BaseFloat> ApproxEq<S> for Basis3<S> {
+impl<S: BaseFloat> ApproxEq for Basis3<S> {
+    type Epsilon = S;
+
     #[inline]
     fn approx_eq_eps(&self, other: &Basis3<S>, epsilon: &S) -> bool {
         self.mat.approx_eq_eps(&other.mat, epsilon)

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -27,8 +27,8 @@ use vector::{Vector, Vector2, Vector3};
 /// creates a circular motion, and preserves at least one point in the space.
 pub trait Rotation<P: Point>: PartialEq + Sized where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
-    Self: ApproxEq<Epsilon = <<P as Point>::Vector as Vector>::Scalar>,
-    <<P as Point>::Vector as Vector>::Scalar: BaseFloat,
+    Self: ApproxEq<Epsilon = <P as Point>::Scalar>,
+    <P as Point>::Scalar: BaseFloat,
 {
     /// Create the identity transform (causes no transformation).
     fn one() -> Self;

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -25,7 +25,9 @@ use vector::{Vector, Vector2, Vector3};
 
 /// A trait for a generic rotation. A rotation is a transformation that
 /// creates a circular motion, and preserves at least one point in the space.
-pub trait Rotation<P: Point>: PartialEq + ApproxEq<Epsilon = <<P as Point>::Vector as Vector>::Scalar> + Sized where
+pub trait Rotation<P: Point>: PartialEq + Sized where
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
+    Self: ApproxEq<Epsilon = <<P as Point>::Vector as Vector>::Scalar>,
     <<P as Point>::Vector as Vector>::Scalar: BaseFloat,
 {
     /// Create the identity transform (causes no transformation).

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -25,7 +25,9 @@ use vector::{Vector, Vector2, Vector3};
 
 /// A trait for a generic rotation. A rotation is a transformation that
 /// creates a circular motion, and preserves at least one point in the space.
-pub trait Rotation<S: BaseFloat, P: Point<S>>: PartialEq + ApproxEq<Epsilon = S> + Sized {
+pub trait Rotation<P: Point>: PartialEq + ApproxEq<Epsilon = <<P as Point>::Vector as Vector>::Scalar> + Sized where
+    <<P as Point>::Vector as Vector>::Scalar: BaseFloat,
+{
     /// Create the identity transform (causes no transformation).
     fn one() -> Self;
 
@@ -67,7 +69,7 @@ pub trait Rotation<S: BaseFloat, P: Point<S>>: PartialEq + ApproxEq<Epsilon = S>
 }
 
 /// A two-dimensional rotation.
-pub trait Rotation2<S: BaseFloat>: Rotation<S, Point2<S>>
+pub trait Rotation2<S: BaseFloat>: Rotation<Point2<S>>
                                  + Into<Matrix2<S>>
                                  + Into<Basis2<S>> {
     /// Create a rotation by a given angle. Thus is a redundant case of both
@@ -76,7 +78,7 @@ pub trait Rotation2<S: BaseFloat>: Rotation<S, Point2<S>>
 }
 
 /// A three-dimensional rotation.
-pub trait Rotation3<S: BaseFloat>: Rotation<S, Point3<S>>
+pub trait Rotation3<S: BaseFloat>: Rotation<Point3<S>>
                                  + Into<Matrix3<S>>
                                  + Into<Basis3<S>>
                                  + Into<Quaternion<S>> {
@@ -172,7 +174,7 @@ impl<S: BaseFloat> From<Basis2<S>> for Matrix2<S> {
     fn from(b: Basis2<S>) -> Matrix2<S> { b.mat }
 }
 
-impl<S: BaseFloat> Rotation<S, Point2<S>> for Basis2<S> {
+impl<S: BaseFloat> Rotation<Point2<S>> for Basis2<S> {
     #[inline]
     fn one() -> Basis2<S> { Basis2 { mat: Matrix2::one() } }
 
@@ -255,7 +257,7 @@ impl<S: BaseFloat> From<Basis3<S>> for Quaternion<S> {
     fn from(b: Basis3<S>) -> Quaternion<S> { b.mat.into() }
 }
 
-impl<S: BaseFloat> Rotation<S, Point3<S>> for Basis3<S> {
+impl<S: BaseFloat> Rotation<Point3<S>> for Basis3<S> {
     #[inline]
     fn one() -> Basis3<S> { Basis3 { mat: Matrix3::one() } }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -80,12 +80,12 @@ pub struct Decomposed<V: Vector, R> {
 
 impl<P: Point, R: Rotation<P>> Transform<P> for Decomposed<P::Vector, R> where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
-    <<P as Point>::Vector as Vector>::Scalar: BaseFloat,
+    <P as Point>::Scalar: BaseFloat,
 {
     #[inline]
     fn one() -> Decomposed<P::Vector, R> {
         Decomposed {
-            scale: <<P as Point>::Vector as Vector>::Scalar::one(),
+            scale: <P as Point>::Scalar::one(),
             rot: R::one(),
             disp: P::Vector::zero(),
         }
@@ -96,7 +96,7 @@ impl<P: Point, R: Rotation<P>> Transform<P> for Decomposed<P::Vector, R> where
         let rot = R::look_at(&center.sub_p(eye), up);
         let disp = rot.rotate_vector(&P::origin().sub_p(eye));
         Decomposed {
-            scale: <<P as Point>::Vector as Vector>::Scalar::one(),
+            scale: <P as Point>::Scalar::one(),
             rot: rot,
             disp: disp,
         }
@@ -121,10 +121,10 @@ impl<P: Point, R: Rotation<P>> Transform<P> for Decomposed<P::Vector, R> where
     }
 
     fn invert(&self) -> Option<Decomposed<P::Vector, R>> {
-        if self.scale.approx_eq(&<<P as Point>::Vector as Vector>::Scalar::zero()) {
+        if self.scale.approx_eq(&<P as Point>::Scalar::zero()) {
             None
         } else {
-            let s = <<P as Point>::Vector as Vector>::Scalar::one() / self.scale;
+            let s = <P as Point>::Scalar::one() / self.scale;
             let r = self.rot.invert();
             let d = r.rotate_vector(&self.disp).mul_s(-s);
             Some(Decomposed {
@@ -215,7 +215,8 @@ impl<S: BaseFloat> Transform3<S> for AffineMatrix3<S> {}
 /// A trait that allows extracting components (rotation, translation, scale)
 /// from an arbitrary transformations
 pub trait ToComponents<P: Point, R: Rotation<P>> where
-    <<P as Point>::Vector as Vector>::Scalar: BaseFloat,
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
+    <P as Point>::Scalar: BaseFloat,
 {
     /// Extract the (scale, rotation, translation) triple
     fn decompose(&self) -> (P::Vector, R, P::Vector);
@@ -226,7 +227,7 @@ pub trait ToComponents3<S: BaseFloat, R: Rotation3<S>>: ToComponents<Point3<S>, 
 
 pub trait CompositeTransform<P: Point, R: Rotation<P>>: Transform<P> + ToComponents<P, R> where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
-    <<P as Point>::Vector as Vector>::Scalar: BaseFloat,
+    <P as Point>::Scalar: BaseFloat,
 {}
 
 pub trait CompositeTransform2<S: BaseFloat, R: Rotation2<S>>: Transform2<S> + ToComponents2<S, R> {}
@@ -234,7 +235,7 @@ pub trait CompositeTransform3<S: BaseFloat, R: Rotation3<S>>: Transform3<S> + To
 
 impl<P: Point, R: Rotation<P> + Clone> ToComponents<P, R> for Decomposed<P::Vector, R> where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
-    <<P as Point>::Vector as Vector>::Scalar: BaseFloat,
+    <P as Point>::Scalar: BaseFloat,
 {
     fn decompose(&self) -> (P::Vector, R, P::Vector) {
         (P::Vector::one().mul_s(self.scale), self.rot.clone(), self.disp.clone())

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -79,6 +79,7 @@ pub struct Decomposed<V: Vector, R> {
 }
 
 impl<P: Point, R: Rotation<P>> Transform<P> for Decomposed<P::Vector, R> where
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     <<P as Point>::Vector as Vector>::Scalar: BaseFloat,
 {
     #[inline]
@@ -224,6 +225,7 @@ pub trait ToComponents2<S: BaseFloat, R: Rotation2<S>>: ToComponents<Point2<S>, 
 pub trait ToComponents3<S: BaseFloat, R: Rotation3<S>>: ToComponents<Point3<S>, R> {}
 
 pub trait CompositeTransform<P: Point, R: Rotation<P>>: Transform<P> + ToComponents<P, R> where
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     <<P as Point>::Vector as Vector>::Scalar: BaseFloat,
 {}
 
@@ -231,6 +233,7 @@ pub trait CompositeTransform2<S: BaseFloat, R: Rotation2<S>>: Transform2<S> + To
 pub trait CompositeTransform3<S: BaseFloat, R: Rotation3<S>>: Transform3<S> + ToComponents3<S, R> {}
 
 impl<P: Point, R: Rotation<P> + Clone> ToComponents<P, R> for Decomposed<P::Vector, R> where
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     <<P as Point>::Vector as Vector>::Scalar: BaseFloat,
 {
     fn decompose(&self) -> (P::Vector, R, P::Vector) {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -287,7 +287,9 @@ macro_rules! vec {
             fn neg(self) -> $VectorN<S> { $VectorN::new($(-self.$field),+) }
         }
 
-        impl<S: BaseFloat> ApproxEq<S> for $VectorN<S> {
+        impl<S: BaseFloat> ApproxEq for $VectorN<S> {
+            type Epsilon = S;
+
             #[inline]
             fn approx_eq_eps(&self, other: &$VectorN<S>, epsilon: &S) -> bool {
                 $(self.$field.approx_eq_eps(&other.$field, epsilon))&&+
@@ -618,7 +620,7 @@ impl<S: BaseNum> Vector4<S> {
 /// Specifies geometric operations for vectors. This is only implemented for
 /// 2-dimensional and 3-dimensional vectors.
 pub trait EuclideanVector<S: BaseFloat>: Vector<S>
-                                       + ApproxEq<S>
+                                       + ApproxEq<Epsilon = S>
                                        + Sized {
     /// Returns `true` if the vector is perpendicular (at right angles) to the
     /// other vector.

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -111,7 +111,7 @@ use num::{BaseNum, BaseFloat};
 /// A trait that specifies a range of numeric operations for vectors. Not all
 /// of these make sense from a linear algebra point of view, but are included
 /// for pragmatic reasons.
-pub trait Vector<S: BaseNum>: Array1<S> + Clone // where
+pub trait Vector<S: BaseNum>: Array1<Element = S> + Clone // where
     // FIXME: blocked by rust-lang/rust#20671
     //
     // for<'a, 'b> &'a Self: Add<&'b Self, Output = Self>,
@@ -245,7 +245,9 @@ macro_rules! vec {
             }
         }
 
-        impl<$S: Copy> Array1<$S> for $VectorN<$S> {}
+        impl<S: Copy> Array1 for $VectorN<S> {
+            type Element = S;
+        }
 
         impl<S: BaseNum> Vector<S> for $VectorN<S> {
             #[inline] fn from_value(s: S) -> $VectorN<S> { $VectorN { $($field: s),+ } }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -111,7 +111,9 @@ use num::{BaseNum, BaseFloat};
 /// A trait that specifies a range of numeric operations for vectors. Not all
 /// of these make sense from a linear algebra point of view, but are included
 /// for pragmatic reasons.
-pub trait Vector: Array1<Element = <Self as Vector>::Scalar> + Clone // where
+pub trait Vector: Clone where
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
+    Self: Array1<Element = <Self as Vector>::Scalar>,
     // FIXME: blocked by rust-lang/rust#20671
     //
     // for<'a, 'b> &'a Self: Add<&'b Self, Output = Self>,
@@ -627,6 +629,7 @@ impl<S: BaseNum> Vector4<S> {
 /// Specifies geometric operations for vectors. This is only implemented for
 /// 2-dimensional and 3-dimensional vectors.
 pub trait EuclideanVector: Vector + Sized where
+    // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     <Self as Vector>::Scalar: BaseFloat,
     Self: ApproxEq<Epsilon = <Self as Vector>::Scalar>,
 {
@@ -647,6 +650,7 @@ pub trait EuclideanVector: Vector + Sized where
     /// The norm of the vector.
     #[inline]
     fn length(&self) -> Self::Scalar {
+        // Not sure why these annotations are needed
         <<Self as Vector>::Scalar as ::rust_num::Float>::sqrt(self.dot(self))
     }
 
@@ -679,6 +683,7 @@ pub trait EuclideanVector: Vector + Sized where
     /// Normalises the vector to a length of `1`.
     #[inline]
     fn normalize_self(&mut self) {
+        // Not sure why these annotations are needed
         let rlen = <<Self as Vector>::Scalar as ::rust_num::Float>::recip(self.length());
         self.mul_self_s(rlen);
     }

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -36,7 +36,7 @@ fn test_look_at() {
 	let eye = Point3::new(0.0f64, 0.0, -5.0);
 	let center = Point3::new(0.0f64, 0.0, 0.0);
 	let up = Vector3::new(1.0f64, 0.0, 0.0);
-	let t: Decomposed<f64,Vector3<f64>,Quaternion<f64>> = Transform::look_at(&eye, &center, &up);
+	let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at(&eye, &center, &up);
 	let point = Point3::new(1.0f64, 0.0, 0.0);
 	let view_point = Point3::new(0.0f64, 1.0, 5.0);
 	assert!( t.transform_point(&point).approx_eq(&view_point) );


### PR DESCRIPTION
rust-lang/rust#24092 has caused quite a bit of ugliness, but I've tried to work around it as best I can.