### PR TITLE
Standardise macro use for code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add missing by-ref and by-val permutations of `Quaternion` operators.
 
+### Removed
+- Remove redundant `Point::{min, max}` methods - these are now covered by the
+  `Array::{min, max}` methods that were introduced in 0.5.0.
+
 ## [v0.6.0] - 2015-12-12
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![crate_type = "rlib"]
-#![crate_type = "dylib"]
-
 //! Computer graphics-centric math.
 //!
 //! This crate provides useful mathematical primitives and operations on them.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ pub use rust_num::{One, Zero, one, zero};
 
 // Modules
 
+mod macros;
+
 mod array;
 
 mod matrix;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,203 @@
+// Copyright 2013-2014 The CGMath Developers. For a full listing of the authors,
+// refer to the Cargo.toml file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utility macros for code generation
+
+#![macro_use]
+
+/// Generates a binary operator implementation for the permutations of by-ref and by-val
+macro_rules! impl_binary_operator {
+    // When the right operand is a scalar
+    (<$S:ident: $Constraint:ident> $Binop:ident<$Rhs:ident> for $Lhs:ty {
+        fn $binop:ident($lhs:ident, $rhs:ident) -> $Output:ty { $body:expr }
+    }) => {
+        impl<$S: $Constraint> $Binop<$Rhs> for $Lhs {
+            type Output = $Output;
+            #[inline]
+            fn $binop(self, other: $Rhs) -> $Output {
+                let ($lhs, $rhs) = (self, other); $body
+            }
+        }
+
+        impl<'a, $S: $Constraint> $Binop<$Rhs> for &'a $Lhs {
+            type Output = $Output;
+            #[inline]
+            fn $binop(self, other: $Rhs) -> $Output {
+                let ($lhs, $rhs) = (self, other); $body
+            }
+        }
+    };
+    // When the right operand is a compound type
+    (<$S:ident: $Constraint:ident> $Binop:ident<$Rhs:ty> for $Lhs:ty {
+        fn $binop:ident($lhs:ident, $rhs:ident) -> $Output:ty { $body:expr }
+    }) => {
+        impl<$S: $Constraint> $Binop<$Rhs> for $Lhs {
+            type Output = $Output;
+            #[inline]
+            fn $binop(self, other: $Rhs) -> $Output {
+                let ($lhs, $rhs) = (self, other); $body
+            }
+        }
+
+        impl<'a, $S: $Constraint> $Binop<&'a $Rhs> for $Lhs {
+            type Output = $Output;
+            #[inline]
+            fn $binop(self, other: &'a $Rhs) -> $Output {
+                let ($lhs, $rhs) = (self, other); $body
+            }
+        }
+
+        impl<'a, $S: $Constraint> $Binop<$Rhs> for &'a $Lhs {
+            type Output = $Output;
+            #[inline]
+            fn $binop(self, other: $Rhs) -> $Output {
+                let ($lhs, $rhs) = (self, other); $body
+            }
+        }
+
+        impl<'a, 'b, $S: $Constraint> $Binop<&'a $Rhs> for &'b $Lhs {
+            type Output = $Output;
+            #[inline]
+            fn $binop(self, other: &'a $Rhs) -> $Output {
+                let ($lhs, $rhs) = (self, other); $body
+            }
+        }
+    };
+}
+
+macro_rules! fold_array {
+    (&$method:ident, { $x:expr, $y:expr })                   => { $x.$method(&$y) };
+    (&$method:ident, { $x:expr, $y:expr, $z:expr })          => { $x.$method(&$y).$method(&$z) };
+    (&$method:ident, { $x:expr, $y:expr, $z:expr, $w:expr }) => { $x.$method(&$y).$method(&$z).$method(&$w) };
+    ($method:ident, { $x:expr, $y:expr })                    => { $x.$method($y) };
+    ($method:ident, { $x:expr, $y:expr, $z:expr })           => { $x.$method($y).$method($z) };
+    ($method:ident, { $x:expr, $y:expr, $z:expr, $w:expr })  => { $x.$method($y).$method($z).$method($w) };
+}
+
+/// Generate array conversion implementations for a compound array type
+macro_rules! impl_fixed_array_conversions {
+    ($ArrayN:ident <$S:ident> { $($field:ident : $index:expr),+ }, $n:expr) => {
+        impl<$S> Into<[$S; $n]> for $ArrayN<$S> {
+            #[inline]
+            fn into(self) -> [$S; $n] {
+                match self { $ArrayN { $($field),+ } => [$($field),+] }
+            }
+        }
+
+        impl<$S> AsRef<[$S; $n]> for $ArrayN<$S> {
+            #[inline]
+            fn as_ref(&self) -> &[$S; $n] {
+                unsafe { mem::transmute(self) }
+            }
+        }
+
+        impl<$S> AsMut<[$S; $n]> for $ArrayN<$S> {
+            #[inline]
+            fn as_mut(&mut self) -> &mut [$S; $n] {
+                unsafe { mem::transmute(self) }
+            }
+        }
+
+        impl<$S: Clone> From<[$S; $n]> for $ArrayN<$S> {
+            #[inline]
+            fn from(v: [$S; $n]) -> $ArrayN<$S> {
+                // We need to use a clone here because we can't pattern match on arrays yet
+                $ArrayN { $($field: v[$index].clone()),+ }
+            }
+        }
+
+        impl<'a, $S> From<&'a [$S; $n]> for &'a $ArrayN<$S> {
+            #[inline]
+            fn from(v: &'a [$S; $n]) -> &'a $ArrayN<$S> {
+                unsafe { mem::transmute(v) }
+            }
+        }
+
+        impl<'a, $S> From<&'a mut [$S; $n]> for &'a mut $ArrayN<$S> {
+            #[inline]
+            fn from(v: &'a mut [$S; $n]) -> &'a mut $ArrayN<$S> {
+                unsafe { mem::transmute(v) }
+            }
+        }
+    }
+}
+
+/// Generate homogeneous tuple conversion implementations for a compound array type
+macro_rules! impl_tuple_conversions {
+    ($ArrayN:ident <$S:ident> { $($field:ident),+ }, $Tuple:ty) => {
+        impl<$S> Into<$Tuple> for $ArrayN<$S> {
+            #[inline]
+            fn into(self) -> $Tuple {
+                match self { $ArrayN { $($field),+ } => ($($field),+) }
+            }
+        }
+
+        impl<$S> AsRef<$Tuple> for $ArrayN<$S> {
+            #[inline]
+            fn as_ref(&self) -> &$Tuple {
+                unsafe { mem::transmute(self) }
+            }
+        }
+
+        impl<$S> AsMut<$Tuple> for $ArrayN<$S> {
+            #[inline]
+            fn as_mut(&mut self) -> &mut $Tuple {
+                unsafe { mem::transmute(self) }
+            }
+        }
+
+        impl<$S> From<$Tuple> for $ArrayN<$S> {
+            #[inline]
+            fn from(v: $Tuple) -> $ArrayN<$S> {
+                match v { ($($field),+) => $ArrayN { $($field: $field),+ } }
+            }
+        }
+
+        impl<'a, $S> From<&'a $Tuple> for &'a $ArrayN<$S> {
+            #[inline]
+            fn from(v: &'a $Tuple) -> &'a $ArrayN<$S> {
+                unsafe { mem::transmute(v) }
+            }
+        }
+
+        impl<'a, $S> From<&'a mut $Tuple> for &'a mut $ArrayN<$S> {
+            #[inline]
+            fn from(v: &'a mut $Tuple) -> &'a mut $ArrayN<$S> {
+                unsafe { mem::transmute(v) }
+            }
+        }
+    }
+}
+
+/// Generates index operators for a compound type
+macro_rules! impl_index_operators {
+    ($VectorN:ident<$S:ident>, $n:expr, $Output:ty, $I:ty) => {
+        impl<$S> Index<$I> for $VectorN<$S> {
+            type Output = $Output;
+
+            #[inline]
+            fn index<'a>(&'a self, i: $I) -> &'a $Output {
+                let v: &[$S; $n] = self.as_ref(); &v[i]
+            }
+        }
+
+        impl<$S> IndexMut<$I> for $VectorN<$S> {
+            #[inline]
+            fn index_mut<'a>(&'a mut self, i: $I) -> &'a mut $Output {
+                let v: &mut [$S; $n] = self.as_mut(); &mut v[i]
+            }
+        }
+    }
+}

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -123,75 +123,19 @@ impl<'a, S: BaseFloat> Neg for &'a Quaternion<S> {
     fn neg(self) -> Quaternion<S> { Quaternion::from_sv(-self.s, -self.v) }
 }
 
-/// Generates a binary operator implementation for the permutations of by-ref and by-val
-macro_rules! impl_binary_operator {
-    // When the right operand is a scalar
-    (<$S:ident> $Binop:ident<$Rhs:ident> for $Lhs:ty { fn $binop:ident($lhs:ident, $rhs:ident) -> $Output:ty { $body:expr } }) => {
-        impl<$S: BaseFloat> $Binop<$Rhs> for $Lhs {
-            type Output = $Output;
-            #[inline]
-            fn $binop(self, other: $Rhs) -> $Output {
-                let ($lhs, $rhs) = (self, other); $body
-            }
-        }
-
-        impl<'a, $S: BaseFloat> $Binop<$Rhs> for &'a $Lhs {
-            type Output = $Output;
-            #[inline]
-            fn $binop(self, other: $Rhs) -> $Output {
-                let ($lhs, $rhs) = (self, other); $body
-            }
-        }
-    };
-    // When the right operand is a compound type
-    (<$S:ident> $Binop:ident<$Rhs:ty> for $Lhs:ty { fn $binop:ident($lhs:ident, $rhs:ident) -> $Output:ty { $body:expr } }) => {
-        impl<$S: BaseFloat> $Binop<$Rhs> for $Lhs {
-            type Output = $Output;
-            #[inline]
-            fn $binop(self, other: $Rhs) -> $Output {
-                let ($lhs, $rhs) = (self, other); $body
-            }
-        }
-
-        impl<'a, $S: BaseFloat> $Binop<&'a $Rhs> for $Lhs {
-            type Output = $Output;
-            #[inline]
-            fn $binop(self, other: &'a $Rhs) -> $Output {
-                let ($lhs, $rhs) = (self, other); $body
-            }
-        }
-
-        impl<'a, $S: BaseFloat> $Binop<$Rhs> for &'a $Lhs {
-            type Output = $Output;
-            #[inline]
-            fn $binop(self, other: $Rhs) -> $Output {
-                let ($lhs, $rhs) = (self, other); $body
-            }
-        }
-
-        impl<'a, 'b, $S: BaseFloat> $Binop<&'a $Rhs> for &'b $Lhs {
-            type Output = $Output;
-            #[inline]
-            fn $binop(self, other: &'a $Rhs) -> $Output {
-                let ($lhs, $rhs) = (self, other); $body
-            }
-        }
-    };
-}
-
-impl_binary_operator!(<S> Mul<S> for Quaternion<S> {
+impl_binary_operator!(<S: BaseFloat> Mul<S> for Quaternion<S> {
     fn mul(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s * rhs, lhs.v * rhs)
     }
 });
 
-impl_binary_operator!(<S> Div<S> for Quaternion<S> {
+impl_binary_operator!(<S: BaseFloat> Div<S> for Quaternion<S> {
     fn div(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s / rhs, lhs.v / rhs)
     }
 });
 
-impl_binary_operator!(<S> Mul<Vector3<S> > for Quaternion<S> {
+impl_binary_operator!(<S: BaseFloat> Mul<Vector3<S> > for Quaternion<S> {
     fn mul(lhs, rhs) -> Vector3<S> {{
         let rhs = rhs.clone();
         let two: S = cast(2i8).unwrap();
@@ -200,19 +144,19 @@ impl_binary_operator!(<S> Mul<Vector3<S> > for Quaternion<S> {
     }}
 });
 
-impl_binary_operator!(<S> Add<Quaternion<S> > for Quaternion<S> {
+impl_binary_operator!(<S: BaseFloat> Add<Quaternion<S> > for Quaternion<S> {
     fn add(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s + rhs.s, lhs.v + rhs.v)
     }
 });
 
-impl_binary_operator!(<S> Sub<Quaternion<S> > for Quaternion<S> {
+impl_binary_operator!(<S: BaseFloat> Sub<Quaternion<S> > for Quaternion<S> {
     fn sub(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s - rhs.s, lhs.v - rhs.v)
     }
 });
 
-impl_binary_operator!(<S> Mul<Quaternion<S> > for Quaternion<S> {
+impl_binary_operator!(<S: BaseFloat> Mul<Quaternion<S> > for Quaternion<S> {
     fn mul(lhs, rhs) -> Quaternion<S> {
         Quaternion::new(lhs.s * rhs.s - lhs.v.x * rhs.v.x - lhs.v.y * rhs.v.y - lhs.v.z * rhs.v.z,
                         lhs.s * rhs.v.x + lhs.v.x * rhs.s + lhs.v.y * rhs.v.z - lhs.v.z * rhs.v.y,


### PR DESCRIPTION
This moves lots of the common code generation patterns into a macros module. In doing so, the code can be greatly reduced in size.

I also removed some redundant component-wise functions that I found on `Point` that are now covered by `Array`.