### PR TITLE
Operator method sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add missing by-ref and by-val permutations of `Quaternion` operators.
 
+### Changed
+- `Vector` and `Point` are now constrained to require specific operators to be
+  overloaded. This means that generic code can now use operators, instead of
+  the operator methods.
+
 ### Removed
 - Remove redundant `Point::{min, max}` methods - these are now covered by the
   `Array::{min, max}` methods that were introduced in 0.5.0.
@@ -17,6 +22,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   accessing the fields on `Decomposed` directly. To create the scale vector,
   use: `Vector::from_value(transform.scale)`.
 - Removed `CompositeTransform`, `CompositeTransform2`, and `CompositeTransform3`.
+- Remove `Vector::one`. Vectors don't really have a multiplicative identity.
+  If you really want a `one` vector, you can do something like:
+  `Vector::from_value(1.0)`.
+- Remove operator methods from `Vector` and `Point` traits in favor of operator
+  overloading.
+- Remove `*_self` methods from `Vector` and `Point`. These were of little
+  performance benefit, and assignment operator overloading will be coming soon!
 
 ## [v0.6.0] - 2015-12-12
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -467,14 +467,14 @@ impl<S: BaseFloat> Matrix for Matrix2<S> {
 
     #[inline]
     fn mul_self_s(&mut self, s: S) {
-        self[0].mul_self_s(s);
-        self[1].mul_self_s(s);
+        self[0] = self[0] * s;
+        self[1] = self[1] * s;
     }
 
     #[inline]
     fn div_self_s(&mut self, s: S) {
-        self[0].div_self_s(s);
-        self[1].div_self_s(s);
+        self[0] = self[0] / s;
+        self[1] = self[1] / s;
     }
 
     fn transpose(&self) -> Matrix2<S> {
@@ -511,14 +511,14 @@ impl<S: BaseFloat> SquareMatrix for Matrix2<S> {
 
     #[inline]
     fn add_self_m(&mut self, m: &Matrix2<S>) {
-        self[0].add_self_v(m[0]);
-        self[1].add_self_v(m[1]);
+        self[0] = self[0] + m[0];
+        self[1] = self[1] + m[1];
     }
 
     #[inline]
     fn sub_self_m(&mut self, m: &Matrix2<S>) {
-        self[0].sub_self_v(m[0]);
-        self[1].sub_self_v(m[1]);
+        self[0] = self[0] - m[0];
+        self[1] = self[1] - m[1];
     }
 
     #[inline]
@@ -615,16 +615,16 @@ impl<S: BaseFloat> Matrix for Matrix3<S> {
 
     #[inline]
     fn mul_self_s(&mut self, s: S) {
-        self[0].mul_self_s(s);
-        self[1].mul_self_s(s);
-        self[2].mul_self_s(s);
+        self[0] = self[0] * s;
+        self[1] = self[1] * s;
+        self[2] = self[2] * s;
     }
 
     #[inline]
     fn div_self_s(&mut self, s: S) {
-        self[0].div_self_s(s);
-        self[1].div_self_s(s);
-        self[2].div_self_s(s);
+        self[0] = self[0] / s;
+        self[1] = self[1] / s;
+        self[2] = self[2] / s;
     }
 
     fn transpose(&self) -> Matrix3<S> {
@@ -664,16 +664,16 @@ impl<S: BaseFloat> SquareMatrix for Matrix3<S> {
 
     #[inline]
     fn add_self_m(&mut self, m: &Matrix3<S>) {
-        self[0].add_self_v(m[0]);
-        self[1].add_self_v(m[1]);
-        self[2].add_self_v(m[2]);
+        self[0] = self[0] + m[0];
+        self[1] = self[1] + m[1];
+        self[2] = self[2] + m[2];
     }
 
     #[inline]
     fn sub_self_m(&mut self, m: &Matrix3<S>) {
-        self[0].sub_self_v(m[0]);
-        self[1].sub_self_v(m[1]);
-        self[2].sub_self_v(m[2]);
+        self[0] = self[0] - m[0];
+        self[1] = self[1] - m[1];
+        self[2] = self[2] - m[2];
     }
 
     #[inline]
@@ -784,18 +784,18 @@ impl<S: BaseFloat> Matrix for Matrix4<S> {
 
     #[inline]
     fn mul_self_s(&mut self, s: S) {
-        self[0].mul_self_s(s);
-        self[1].mul_self_s(s);
-        self[2].mul_self_s(s);
-        self[3].mul_self_s(s);
+        self[0] = self[0] * s;
+        self[1] = self[1] * s;
+        self[2] = self[2] * s;
+        self[3] = self[3] * s;
     }
 
     #[inline]
     fn div_self_s(&mut self, s: S) {
-        self[0].div_self_s(s);
-        self[1].div_self_s(s);
-        self[2].div_self_s(s);
-        self[3].div_self_s(s);
+        self[0] = self[0] / s;
+        self[1] = self[1] / s;
+        self[2] = self[2] / s;
+        self[3] = self[3] / s;
     }
 
     fn transpose(&self) -> Matrix4<S> {
@@ -838,18 +838,18 @@ impl<S: BaseFloat> SquareMatrix for Matrix4<S> {
 
     #[inline]
     fn add_self_m(&mut self, m: &Matrix4<S>) {
-        self[0].add_self_v(m[0]);
-        self[1].add_self_v(m[1]);
-        self[2].add_self_v(m[2]);
-        self[3].add_self_v(m[3]);
+        self[0] = self[0] + m[0];
+        self[1] = self[1] + m[1];
+        self[2] = self[2] + m[2];
+        self[3] = self[3] + m[3];
     }
 
     #[inline]
     fn sub_self_m(&mut self, m: &Matrix4<S>) {
-        self[0].sub_self_v(m[0]);
-        self[1].sub_self_v(m[1]);
-        self[2].sub_self_v(m[2]);
-        self[3].sub_self_v(m[3]);
+        self[0] = self[0] - m[0];
+        self[1] = self[1] - m[1];
+        self[2] = self[2] - m[2];
+        self[3] = self[3] - m[3];
     }
 
     fn transpose_self(&mut self) {

--- a/src/point.rs
+++ b/src/point.rs
@@ -69,14 +69,13 @@ impl<S: BaseNum> Point3<S> {
 pub trait Point: Copy + Clone where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     Self: Array<Element = <Self as Point>::Scalar>,
-    // FIXME: blocked by rust-lang/rust#20671
-    //
-    // for<'a, 'b> &'a Self: Add<&'b V, Output = Self>,
-    // for<'a, 'b> &'a Self: Sub<&'b Self, Output = V>,
-    //
-    // for<'a> &'a Self: Mul<S, Output = Self>,
-    // for<'a> &'a Self: Div<S, Output = Self>,
-    // for<'a> &'a Self: Rem<S, Output = Self>,
+
+    Self: Add<<Self as Point>::Vector, Output = Self>,
+    Self: Sub<Self, Output = <Self as Point>::Vector>,
+
+    Self: Mul<<Self as Point>::Scalar, Output = Self>,
+    Self: Div<<Self as Point>::Scalar, Output = Self>,
+    Self: Rem<<Self as Point>::Scalar, Output = Self>,
 {
     /// The associated scalar.
     ///
@@ -93,32 +92,6 @@ pub trait Point: Copy + Clone where
     fn from_vec(v: Self::Vector) -> Self;
     /// Convert a point to a vector.
     fn to_vec(self) -> Self::Vector;
-
-    /// Multiply each component by a scalar, returning the new point.
-    #[must_use]
-    fn mul_s(self, scalar: Self::Scalar) -> Self;
-    /// Divide each component by a scalar, returning the new point.
-    #[must_use]
-    fn div_s(self, scalar: Self::Scalar) -> Self;
-    /// Subtract a scalar from each component, returning the new point.
-    #[must_use]
-    fn rem_s(self, scalar: Self::Scalar) -> Self;
-
-    /// Add a vector to this point, returning the new point.
-    #[must_use]
-    fn add_v(self, v: Self::Vector) -> Self;
-    /// Subtract another point from this one, returning a new vector.
-    fn sub_p(self, p: Self) -> Self::Vector;
-
-    /// Multiply each component by a scalar, in-place.
-    fn mul_self_s(&mut self, scalar: Self::Scalar);
-    /// Divide each component by a scalar, in-place.
-    fn div_self_s(&mut self, scalar: Self::Scalar);
-    /// Take the remainder of each component by a scalar, in-place.
-    fn rem_self_s(&mut self, scalar: Self::Scalar);
-
-    /// Add a vector to this point, in-place.
-    fn add_self_v(&mut self, v: Self::Vector);
 
     /// This is a weird one, but its useful for plane calculations.
     fn dot(self, v: Self::Vector) -> Self::Scalar;
@@ -153,16 +126,6 @@ macro_rules! impl_point {
             fn to_vec(self) -> $VectorN<S> {
                 $VectorN::new($(self.$field),+)
             }
-
-            #[inline] fn mul_s(self, scalar: S) -> $PointN<S> { self * scalar }
-            #[inline] fn div_s(self, scalar: S) -> $PointN<S> { self / scalar }
-            #[inline] fn rem_s(self, scalar: S) -> $PointN<S> { self % scalar }
-            #[inline] fn add_v(self, v: $VectorN<S>) -> $PointN<S> { self + v }
-            #[inline] fn sub_p(self, p: $PointN<S>) -> $VectorN<S> { self - p }
-            #[inline] fn mul_self_s(&mut self, scalar: S) { *self = *self * scalar; }
-            #[inline] fn div_self_s(&mut self, scalar: S) { *self = *self / scalar; }
-            #[inline] fn rem_self_s(&mut self, scalar: S) { *self = *self % scalar; }
-            #[inline] fn add_self_v(&mut self, vector: $VectorN<S>) { *self = *self + vector; }
 
             #[inline]
             fn dot(self, v: $VectorN<S>) -> S {

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -363,7 +363,7 @@ impl<S: BaseFloat> Rotation3<S> for Quaternion<S> where S: 'static {
     #[inline]
     fn from_axis_angle(axis: Vector3<S>, angle: Rad<S>) -> Quaternion<S> {
         let (s, c) = sin_cos(angle.mul_s(cast(0.5f64).unwrap()));
-        Quaternion::from_sv(c, axis.mul_s(s))
+        Quaternion::from_sv(c, axis * s)
     }
 
     /// - [Maths - Conversion Euler to Quaternion]

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -93,8 +93,8 @@ impl<P: Point, R: Rotation<P>> Transform<P> for Decomposed<P::Vector, R> where
 
     #[inline]
     fn look_at(eye: P, center: P, up: P::Vector) -> Decomposed<P::Vector, R> {
-        let rot = R::look_at(center.sub_p(eye.clone()), up);
-        let disp = rot.rotate_vector(P::origin().sub_p(eye));
+        let rot = R::look_at(center - eye, up);
+        let disp = rot.rotate_vector(P::origin() - eye);
         Decomposed {
             scale: <P as Point>::Scalar::one(),
             rot: rot,
@@ -109,7 +109,7 @@ impl<P: Point, R: Rotation<P>> Transform<P> for Decomposed<P::Vector, R> where
 
     #[inline]
     fn transform_point(&self, point: P) -> P {
-        self.rot.rotate_point(point.mul_s(self.scale)).add_v(self.disp.clone())
+        self.rot.rotate_point(point * self.scale) + self.disp
     }
 
     fn concat(&self, other: &Decomposed<P::Vector, R>) -> Decomposed<P::Vector, R> {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -81,6 +81,8 @@ pub struct Decomposed<V: Vector, R> {
 impl<P: Point, R: Rotation<P>> Transform<P> for Decomposed<P::Vector, R> where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     <P as Point>::Scalar: BaseFloat,
+    // FIXME: Investigate why this is needed!
+    <P as Point>::Vector: Vector,
 {
     #[inline]
     fn one() -> Decomposed<P::Vector, R> {
@@ -104,7 +106,7 @@ impl<P: Point, R: Rotation<P>> Transform<P> for Decomposed<P::Vector, R> where
 
     #[inline]
     fn transform_vector(&self, vec: P::Vector) -> P::Vector {
-        self.rot.rotate_vector(vec.mul_s(self.scale))
+        self.rot.rotate_vector(vec * self.scale)
     }
 
     #[inline]
@@ -126,7 +128,7 @@ impl<P: Point, R: Rotation<P>> Transform<P> for Decomposed<P::Vector, R> where
         } else {
             let s = <P as Point>::Scalar::one() / self.scale;
             let r = self.rot.invert();
-            let d = r.rotate_vector(self.disp.clone()).mul_s(-s);
+            let d = r.rotate_vector(self.disp.clone()) * -s;
             Some(Decomposed {
                 scale: s,
                 rot: r,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -324,13 +324,6 @@ impl<S: BaseNum> Vector3<S> {
                      (self.x * other.y) - (self.y * other.x))
     }
 
-    /// Calculates the cross product of the vector and `other`, then stores the
-    /// result in `self`.
-    #[inline]
-    pub fn cross_self(&mut self, other: Vector3<S>) {
-        *self = self.cross(other)
-    }
-
     /// Create a `Vector4`, using the `x`, `y` and `z` values from this vector, and the
     /// provided `w`.
     #[inline]
@@ -414,7 +407,7 @@ pub trait EuclideanVector: Vector + Sized where
     /// The norm of the vector.
     #[inline]
     fn length(self) -> Self::Scalar {
-        // Not sure why these annotations are needed
+        // FIXME: Not sure why this annotation is needed
         <<Self as Vector>::Scalar as ::rust_num::Float>::sqrt(self.dot(self))
     }
 
@@ -442,28 +435,6 @@ pub trait EuclideanVector: Vector + Sized where
     #[must_use]
     fn lerp(self, other: Self, amount: Self::Scalar) -> Self {
         self + ((other - self) * amount)
-    }
-
-    /// Normalises the vector to a length of `1`.
-    #[inline]
-    fn normalize_self(&mut self) {
-        // Not sure why these annotations are needed
-        let rlen = <<Self as Vector>::Scalar as ::rust_num::Float>::recip(self.length());
-        *self = *self * rlen;
-    }
-
-    /// Normalizes the vector to `length`.
-    #[inline]
-    fn normalize_self_to(&mut self, length: Self::Scalar) {
-        let n = length / self.length();
-        *self = *self * n;
-    }
-
-    /// Linearly interpolates the length of the vector towards the length of
-    /// `other` by the specified amount.
-    fn lerp_self(&mut self, other: Self, amount: Self::Scalar) {
-        let v = (other - *self) * amount;
-        *self = *self * v;
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -41,7 +41,6 @@
 //!
 //! assert_eq!(a + b, Vector2::zero());
 //! assert_eq!(-(a * b), Vector2::new(9.0f64, 16.0f64));
-//! assert_eq!(a / Vector2::one(), a);
 //!
 //! // As with Rust's `int` and `f32` types, Vectors of different types cannot
 //! // be added and so on with impunity. The following will fail to compile:
@@ -126,12 +125,9 @@ pub trait Vector: Copy + Clone where
     /// Construct a vector from a single value, replicating it.
     fn from_value(scalar: Self::Scalar) -> Self;
 
-    /// The zero vector (with all components set to zero)
+    /// The additive identity vector. Adding this vector with another has no effect.
     #[inline]
     fn zero() -> Self { Self::from_value(Self::Scalar::zero()) }
-    /// The identity vector (with all components set to one)
-    #[inline]
-    fn one() -> Self { Self::from_value(Self::Scalar::one()) }
 
     /// Vector dot product
     fn dot(self, other: Self) -> Self::Scalar;

--- a/tests/projection.rs
+++ b/tests/projection.rs
@@ -15,7 +15,7 @@
 
 extern crate cgmath;
 
-use cgmath::{Vector4, ortho, Matrix, Matrix4, Vector};
+use cgmath::{Vector4, ortho, Matrix, Matrix4};
 
 #[test]
 fn test_ortho_scale() {

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -90,10 +90,6 @@ fn test_cross() {
     let b = Vector3::new(4isize, 5isize, 6isize);
     let r = Vector3::new(-3isize, 6isize, -3isize);
     assert_eq!(a.cross(b), r);
-
-    let mut a = a;
-    a.cross_self(b);
-    assert_eq!(a, r);
 }
 
 #[test]


### PR DESCRIPTION
- Removes the operator methods from `Vector` and `Point` traits #267
- Removes `*_self` methods from `Vector`and `Point` traits
- Removes `Vector::one` #270